### PR TITLE
Poprawki (głównie językowe)

### DIFF
--- a/pl/css-advanced-selectors/css-pseudoclasses.md
+++ b/pl/css-advanced-selectors/css-pseudoclasses.md
@@ -1,6 +1,6 @@
 ## Pseudoklasy CSS
 
-Czy wiecie, że możecie tworzyć interaktywne efekty za pomocą CSS? Poznajcie **pseudoklasy**! Można je rozpoznać po charakterystycznym dwukropku przed nazwą - `:`.
+Czy wiecie, że możecie tworzyć interaktywne efekty za pomocą CSS? Poznajcie <b>pseudoklasy</b>! Można je rozpoznać po charakterystycznym dwukropku przed nazwą – `:`.
 
 ```css
 selektor:pseudoklasa {
@@ -8,7 +8,7 @@ selektor:pseudoklasa {
 }
 ```
 
-Pseudoklasy zazwyczaj dotyczą **stanu** w jakim może znajdować się dany element. Przykładowo, w przypadku linków mogą to być:
+Pseudoklasy zazwyczaj dotyczą <b>stanu</b>, w jakim może znajdować się dany element. Przykładowo, w przypadku linków mogą to być:
 
 ```css
 /*
@@ -49,7 +49,7 @@ a:active {
   <a href="http://theawwwesomes.org">Hej! Jestem linkiem!</a>
 </div>
 
-Kiedy na przykład najedziemy kursorem myszy na nasz element, zmieni on swój kolor na czerwony. 
+Kiedy na przykład najedziemy kursorem myszy na nasz element, zmieni on swój kolor na czerwony.
 
 Różne pseudoklasy możemy aplikować dla różnych elementów, w zależności od ich własności.
 
@@ -75,7 +75,7 @@ label > input[type="checkbox"]:checked {
 }
 ```
 
-Ciekawymi typami pseudoklas są `:first-child`, `:last-child` oraz `:nth-child()`. Zapewne domyślacie się już, że pomagają nam one wybrać elementy w zależności od tego, w którym miejscu występują wobec nadrzędnego elementu. Zaprezentujmy działanie powyższych selektorów na przykładzie... listy zakupów!
+Ciekawymi typami pseudoklas są `:first-child`, `:last-child` oraz `:nth-child()`. Zapewne domyślacie się już, że pomagają nam one wybrać elementy w zależności od tego, w którym miejscu występują wobec nadrzędnego elementu. Zaprezentujmy działanie powyższych selektorów na przykładzie… listy zakupów!
 
 ```html
 <label>Do kupienia:</label>
@@ -126,6 +126,6 @@ Ciekawymi typami pseudoklas są `:first-child`, `:last-child` oraz `:nth-child()
 </ul>
 </div>
 
-Pseudoselektor `:first-child` pozwala nam na wskazanie pierwszego elementu na liście, `:last-child` natomiast ostatniego. `:nth-child()` jest nieco bardziej uniwersalny, ponieważ wewnątrz nawiasów `()` możemy podać dowolną liczbę naturalną a także warunek, który powinien spełniać element. Przykładowo `:nth-child(2n)` wskaże wszystkie elementy zajmujące parzyste pozycje na liście, a `nth-child(2n + 1)` - nieparzyste.
+Pseudoselektor `:first-child` pozwala nam na wskazanie pierwszego elementu na liście, `:last-child` natomiast ostatniego. `:nth-child()` jest nieco bardziej uniwersalny, ponieważ wewnątrz nawiasów `()` możemy podać dowolną liczbę naturalną a także warunek, który powinien spełniać element. Przykładowo `:nth-child(2n)` wskaże wszystkie elementy zajmujące parzyste pozycje na liście, a `nth-child(2n + 1)` – nieparzyste.
 
-Pełną listę dostępnych pseudoklas (a jest ona całkiem długa!) możecie znaleźć [tutaj](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes).
+Pełną listę dostępnych pseudoklas (a jest ona całkiem długa!) możecie znaleźć [na MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes).

--- a/pl/css-advanced-selectors/css-pseudoelements.md
+++ b/pl/css-advanced-selectors/css-pseudoelements.md
@@ -14,7 +14,7 @@ Jednymi z najczęściej używanych pseudoelementów są `::before` oraz `::after
 
 > ####Important::Ważne
 >
-> Istotne jest, aby wewnątrz selektora pseudoelementu (`::before` tak samo jak `::after`) znajdowała się właściwość `content` mówiąca o zawartości tekstowej pseudoelementu. Może się zdarzyć, że nie chcemy wstawiać żadnego tekstu do pseudoelementu, ponieważ jest on tam całkowicie zbędny - wtedy jako wartość właściwości `content` wystarczy podać spację.
+> Istotne jest, aby wewnątrz selektora pseudoelementu (`::before` tak samo jak `::after`) znajdowała się właściwość `content` mówiąca o zawartości tekstowej pseudoelementu. Może się zdarzyć, że nie chcemy wstawiać żadnego tekstu do pseudoelementu, ponieważ jest on tam całkowicie zbędny – wtedy jako wartość właściwości `content` wystarczy podać spację lub pusty ciąg (` ` lub ``).
 
 Powyższe pseudoelementy mogą mieć [wiele różnorodnych zastosowań](https://css-tricks.com/pseudo-element-roundup/). Poniżej prezentujemy kilka z najczęściej używanych.
 
@@ -49,7 +49,7 @@ Przykładowo, możemy zmienić domyślne, nudne kropki przy elementach listy na 
   </ul>
 </div>
 
-Pseudoelementy okazują się także bardzo przydatne, kiedy chcemy dodać podpowiedzi (*tooltipy*) w jakimś miejscu na stronie.
+Pseudoelementy okazują się także bardzo przydatne, kiedy chcemy dodać podpowiedzi (<i>tooltipy</i>) w jakimś miejscu na stronie.
 
 ```html
 <a href="http://theawwwesomes.org" class="tooltip">
@@ -85,9 +85,9 @@ Pseudoelementy okazują się także bardzo przydatne, kiedy chcemy dodać podpow
   <a href="http://theawwwesomes.org" class="tooltip">The Awwwesomes</a>
 </div>
 
-Przypomnijmy sobie teraz przykład z [rozdziału 14.2](../css-layout/css-floats.md), w którym próbowaliśmy sobie radzić z *czyszczeniem* opływania za pomocą dodatkowego, pustego elementu HTML. Zapowiedzieliśmy już wtedy, że można to zrobić w dużo bardziej elegancki sposób używając właśnie pseudoelementów.
+Przypomnijmy sobie teraz przykład z [rozdziału 14.2](../css-layout/css-floats.md), w którym próbowaliśmy sobie radzić z <i>czyszczeniem</i> opływania za pomocą dodatkowego, pustego elementu HTML. Zapowiedzieliśmy już wtedy, że można to zrobić w dużo bardziej elegancki sposób używając właśnie pseudoelementów.
 
-Poniżej prezentujemy [*micro-clearfix*](http://nicolasgallagher.com/micro-clearfix-hack/)
+Poniżej prezentujemy [<i>micro-clearfix</i>](http://nicolasgallagher.com/micro-clearfix-hack/)
 
 ```css
 .clearfix::before,
@@ -97,7 +97,7 @@ Poniżej prezentujemy [*micro-clearfix*](http://nicolasgallagher.com/micro-clear
 }
 
 .clearfix::after {
-  clear: both; /* Pseudoelement zamiast pustego div'a */ 
+  clear: both; /* Pseudoelement zamiast pustego div'a */
 }
 ```
 
@@ -120,11 +120,11 @@ Poniżej prezentujemy [*micro-clearfix*](http://nicolasgallagher.com/micro-clear
   </div>
 </div>
 
-Dodanie zadeklarowanej powyżej klasy `clearfix` sprawi, że wewnątrz konenera powstanie pseudoelement i nie będzie już potrzeby dodawania zupełnie zbędnago, pustego elementu HTML.
+Dodanie zadeklarowanej powyżej klasy `clearfix` sprawi, że wewnątrz kontenera powstanie pseudoelement i nie będzie już potrzeby dodawania zupełnie zbędnego, pustego elementu HTML.
 
 > ####Important::Ważne
 >
-> Niestety, nie jest możliwe dodanie powyższych pseudoelementów dla elementów *pustych*, czyli między innymi `<img>` lub `<input>.`
+> Niestety, nie jest możliwe dodanie powyższych pseudoelementów dla elementów <i>pustych</i>, czyli między innymi `<img>` lub `<input>.`
 
 ### Inne pseudoelementy
 

--- a/pl/css-animations/README.md
+++ b/pl/css-animations/README.md
@@ -1,13 +1,11 @@
 # Animacje w CSS
 
-Nareszcie przyszła pora, żeby potestować inne, szalone zastosowania CSS i ożywić trochę naszą stronę. Zapraszamy na rozdział poświęcony animacjom! 
-Animacje w CSS są bardzo przyjemnym tematem, gdyż dzięki nim można stworzyć bardzo ciekawe efekty, wykorzystując jedynie podstawową znajomość CSS. 
+Nareszcie przyszła pora, żeby potestować inne, szalone zastosowania CSS i ożywić trochę naszą stronę. Zapraszamy do rozdziału poświęconego animacjom!
+Animacje w CSS są bardzo przyjemnym tematem, gdyż dzięki nim można stworzyć bardzo ciekawe efekty, wykorzystując jedynie podstawową znajomość CSS.
 W tym rozdziale zapoznasz się z funkcją przejścia `transition`, tworzeniem animacji `@keyframes` oraz funkcji przekształcającej `transform`.
 
-Warto wspomnieć, że animacje są też coraz szerzej wspierane przez różnego rodzaju przeglądarki. Pamiętajmy jednak, żeby sprawdzić jak wspierane są wykorzystywane przez nas właściwości CSS. Poniżej znajdziecie wykaz ze strony <a href="http://caniuse.com" traget="_blank">Can I use</a>, który obrazuje wsparcie animacji CSS. 
+Warto wspomnieć, że animacje są też coraz szerzej wspierane przez różnego rodzaju przeglądarki. Pamiętajmy jednak, żeby sprawdzić jak wspierane są wykorzystywane przez nas właściwości CSS. Poniżej znajdziecie wykaz ze strony <a href="http://caniuse.com" traget="_blank">Can I use</a>, który obrazuje wsparcie animacji CSS.
 
 
 ![Tablica z "caniuse.com"][1]
 [1]: /images/caniuse-anim.jpg
-
-

--- a/pl/css-animations/css-keyframes/README.md
+++ b/pl/css-animations/css-keyframes/README.md
@@ -1,4 +1,4 @@
-# Tworzenie animacji - `@keyframes`
+# Tworzenie animacji – `@keyframes`
 
 Tworzenie animacji następuje przez regułę `@keyframes`. Zobaczmy jak wygląda przykładowa animacja.
 ```css
@@ -10,15 +10,15 @@ Tworzenie animacji następuje przez regułę `@keyframes`. Zobaczmy jak wygląda
 }
 ```
 
-`changeColors` to nazwa animacji, którą nadajemy sami. Nastepuje zawsze po deklaracji `@keyframes `.
-W środku animacji, pomiędzy nawiasami klamrowymi definiujemy co będzie działo się w danych przedziałach czasowych animacji. W przypadku CSS przypisuje się to postępowi animacji, wyrażonemu w procentach, gdzie `0%` to początek animacji, zaś `100%` to jej koniec.
+`changeColors` to nazwa animacji, którą nadajemy sami. Nastepuje zawsze po deklaracji `@keyframes`.
+W środku animacji, pomiędzy nawiasami klamrowymi, definiujemy, co będzie działo się w danych przedziałach czasowych animacji. W przypadku CSS przypisuje się to postępowi animacji, wyrażonemu w procentach, gdzie `0%` to początek animacji, zaś `100%` to jej koniec.
 
 Animacja `changeColors` będzie zatem zmieniać kolory tła przycisku z pomarańczowego na granatowy, i na odwrót.
 
 <a href="" class="awww-exercise-link added-transition" style="background-color: salmon; animation-name: changeColors; animation-duration: 5s; padding: 10px 120px; margin: 20px 0;  color: #fff;">to jest link</a>
 
-Animację dodajemy do wybranego selektora lub selektorów CSS. 
-Jak to się robi?Zerknijmy na kod odpowiedzialny za link.
+Animację dodajemy do wybranego selektora lub selektorów CSS.
+Jak to się robi? Zerknijmy na kod odpowiedzialny za link.
 
 ```html
 <a href="" class="link">to jest link</a>
@@ -29,47 +29,46 @@ a.link {
 	padding: 10px 120px;
 	background-color: salmon;
 	color: #fff;
-	animation-name: changeColors; 
+	animation-name: changeColors;
 	animation-duration: 5s;
 }
 ```
-Dodaliśmy dwie nowe właściwości: `animation-name`, której wartością jest nazwa naszej animacji (`changeColors`) oraz `animation-duration`, czyli dowolny czas trwania animacji.
+Dodaliśmy dwie nowe właściwości: `animation-name`, której wartością jest nazwa naszej animacji (`changeColors`), oraz `animation-duration`, czyli dowolny czas trwania animacji.
 Dzięki tym dwóm właściwościom dodaliśmy do naszego linku z klasą `link` stworzoną przez nas animację.
 
 Animacje CSS posiadają jeszcze inne parametry. Poznajmy te najczęściej używane:
-- `animation-name` - nazwa animacji
-- `animation-duration` - czas trwania animacji
+- `animation-name` – nazwa animacji
+- `animation-duration` – czas trwania animacji
 - `animation-timing-function`
-- `animation-delay` - opóźnienie, czyli czas po jakim animacja zacznie działać
-- `animation-direction` - kierunek rozpoczęcia i powtarzania się animacji, więcej o tej właściwości poniżej
-- `animation-iteration-count` - liczba powtórzeń (iteracji) animacji
-- `animation-fill-mode` - określa jakie cechy będzie miał animowany obiekty, gdy jego animacja będzie gdy animacja się zakończy i nie będzie powtarzana.
-- `animation-play-state`- zatrzymywanie bądź wznowienie animacji, dozwolone wartości to `paused` (zatrzymana) i `running` (w toku)
+- `animation-delay` – opóźnienie, czyli czas po jakim animacja zacznie działać
+- `animation-direction` – kierunek rozpoczęcia i powtarzania się animacji, więcej o tej właściwości poniżej
+- `animation-iteration-count` – liczba powtórzeń (iteracji) animacji
+- `animation-fill-mode` – określa jakie cechy będzie miał animowany obiekty, gdy jego animacja będzie gdy animacja się zakończy i nie będzie powtarzana.
+- `animation-play-state`– zatrzymywanie bądź wznowienie animacji, dozwolone wartości to `paused` (zatrzymana) i `running` (w toku)
 
 ## Kierunek animacji, czyli `animation-direction`
-- `alternate` - animacja będzie powtarzać się w odwrotnym kierunku niż przy rozpoczęciu
+- `alternate` – animacja będzie powtarzać się w odwrotnym kierunku niż przy rozpoczęciu.
 
 <div class="circle-ch-anim" style="animation-direction: alternate;"></div>
 
-- `reverse` - animacja rozpoczynać się od miejsca, w którym się zakończyła
+- `reverse` – animacja rozpoczynać się od miejsca, w którym się zakończyła.
 
 <div class="circle-ch-anim" style="animation-direction: reverse;"></div>
 
-- `alternate-reverse` - animacja będzie powtarzana od końca i zostanie powtarzana w w miejscu, w którym się zakonczyła
+- `alternate-reverse` – animacja będzie powtarzana od końca i będzie powtarzana w miejscu, w którym się zakończyła.
 
 <div class="circle-ch-anim" style="animation-direction: alternate-reverse;"></div>
 
-- `normal` animacja będzie rozpoczynała się od początku, w miejscu, w którym pierwotnie zaczęła
+- `normal` – animacja będzie rozpoczynała się od początku, w miejscu, w którym się pierwotnie zaczęła.
 
 <div class="circle-ch-anim" style="animation-direction: normal;"></div>
 
 
 ## Skrótowy zapis
-Tak samo jak do `transition`, do animacji również możemy zastosować skrót właściwości. 
-Zamiast pisać wypisywać oddzielnie kolejne właściwości, możemy wymienić je w jednej linii.
+Tak samo jak w przypadku `transition`, do animacji również możemy zastosować skrót właściwości.
+Zamiast wypisywać oddzielnie kolejne właściwości, możemy wymienić je w jednej linii.
 `animation: 3s ease-in 1s 2 reverse both paused changeColors;`
 
 Skrót ten tworzymy według wzorca:
-`animation: duration | timing-function | delay | iteration-count | direction | fill-mode | play-state | name`, 
+`animation: duration | timing-function | delay | iteration-count | direction | fill-mode | play-state | name`,
 podając przy tym odpowiednie wartości.
-

--- a/pl/css-animations/css-keyframes/README.md
+++ b/pl/css-animations/css-keyframes/README.md
@@ -39,7 +39,7 @@ Dzięki tym dwóm właściwościom dodaliśmy do naszego linku z klasą `link` s
 Animacje CSS posiadają jeszcze inne parametry. Poznajmy te najczęściej używane:
 - `animation-name` – nazwa animacji
 - `animation-duration` – czas trwania animacji
-- `animation-timing-function`
+- `animation-timing-function` – funkcja czasowa animacji; mamy do dyspozycji te same funkcje, co w przypadku `transition`
 - `animation-delay` – opóźnienie, czyli czas po jakim animacja zacznie działać
 - `animation-direction` – kierunek rozpoczęcia i powtarzania się animacji, więcej o tej właściwości poniżej
 - `animation-iteration-count` – liczba powtórzeń (iteracji) animacji

--- a/pl/css-animations/css-transform/README.md
+++ b/pl/css-animations/css-transform/README.md
@@ -1,10 +1,10 @@
-# Przekszałcanie `transform`
+# Przekształcanie `transform`
 
-Dzięki właściwości `transform` możemy przekształcić nasze obiekty w różny sposób. Zajmiemy się przypadkami w przestrzeni 2D. Możliwe operacje to skalowanie (zwiększanie, zmniejszanie), przesuwanie w osi x i w osi y, obrót oraz pochylenie.
+Dzięki właściwości `transform` możemy przekształcić nasze obiekty w różny sposób. Zajmiemy się przypadkami w przestrzeni 2D. Możliwe operacje to skalowanie (zwiększanie, zmniejszanie), przesuwanie po osi X i po osi Y, obrót oraz pochylenie.
 
-## Przesuwanie 
-### Przesuwanie wzdłuż osi x
-Przesuwanie w wzdłuż w osi x, czyli w prawo lub w lewo to właściwość `translateX(wartość)`.
+## Przesuwanie
+### Przesuwanie wzdłuż osi X
+Przesuwanie wzdłuż osi X, czyli w prawo lub w lewo, to właściwość `translateX(wartość)`.
 W poniższym przykładzie element zostanie przesunięty o 150px w prawo.
 ```css
 	transform: translateX(150px);
@@ -15,8 +15,8 @@ Spróbujmy do naszej wartości dodać znak `-`. W wyniku poniższej deklaracji e
 	transform: translateX(-150px);
 ```
 
-### Przesuwanie wzdłuż osi y
-Przesuwanie w wzdłuż w osi y, czyli w górę lub w dół to właściwość `translateY(wartość)`.
+### Przesuwanie wzdłuż osi Y
+Przesuwanie wzdłuż osi Y, czyli w górę lub w dół, to właściwość `translateY(wartość)`.
 W poniższym przykładzie element zostanie przesunięty w górę o 150px.
 ```css
 	transform: translateY(150px);
@@ -28,19 +28,19 @@ Zaś w tym przykładzie, element przesunięty zostanie 150px w dół, gdyż prze
 ```
 
 ## Obracanie
-Dowolne elementy możemy obracać przy wykorzystaniu właściwości `rotate(wartość)`. Wartość podawana jest w stopniach (`deg`). 
+Dowolne elementy możemy obracać przy wykorzystaniu właściwości `rotate(wartość)`. Wartość podawana jest w stopniach (`deg`).
 
-Zobaczmy, co stało się z kwadratem, do którego przypisaliśmy poniższą właściwość 
+Zobaczmy, co stanie się z kwadratem, do którego przypiszemy poniższą właściwość:
 ```css
 	transform: rotate(45deg);
 ```
-Element został obrócony o 45 stopni .
+Jak widać, element został obrócony o 45 stopni.
 
 <div class="rectangle-ch-anim"></div>
 
 <div class="rectangle-ch-anim" style="transform: rotate(45deg);"></div>
 
-Obroty mogą być dokonywane według trzech osi: `x`, `y` i `z`.
+Obroty mogą być dokonywane według trzech osi: X, Y i Z.
 ```css
 	rotateX(45deg);
 	rotateY(45deg);
@@ -48,11 +48,11 @@ Obroty mogą być dokonywane według trzech osi: `x`, `y` i `z`.
 ```
 
 ## Skalowanie
-Wybrany element możemy powiększać lub pomniejszać podając odpowiednie wartości we właściwości 
+Wybrany element możemy powiększać lub pomniejszać podając odpowiednie wartości we właściwości
 ```css
 	transform: scale(wartość);
 ```
-Wartości poniżej 1, będą pomniejszać, zaś powyżej 1 powiększać nasz obiekt.
+Wartości poniżej 1 będą pomniejszać element, zaś powyżej 1 – powiększać nasz obiekt.
 Obiekty od lewej posiadają wartości `scale(0.8)`, `scale(1)` i `scale(1.2)`.
 
 <div class="rectangle-ch-anim" style="transform: scale(0.8); background-color: #FF9F94;"></div>
@@ -77,17 +77,17 @@ Przy zastosowaniu pseudoklasy `:hover` możemy tworzyć ciekawe efekty związane
     transform: scale(1.2);  
 }
 ```
-### Skalowanie w osi X i Y
-Skalowanie może się też odbywać tylko w wybranej osi. Służą do tego właściwości:
+### Skalowanie na osi X i Y
+Skalowanie może się też odbywać tylko na wybranej osi. Służą do tego właściwości:
 
 `transform: scaleX(wartość);`
 
 `transform: scaleY(wartość);`
 
 ## Pochylenie
-Pochylenie (przekoszenie) elementu może wystepować w dwóch osiach: X i Y. 
-Pochylenie w osi X definiujemy poprzez właściwość: ` transform: skewX(wartość);`
-zaś w osi Y: ` transform: skewY(wartość);`. Wartość podawana jest w stopniach (`deg`). 
+Pochylenie ("przekoszenie") elementu może wystepować na dwóch osiach: X i Y.
+Pochylenie na osi X definiujemy poprzez właściwość: ` transform: skewX(wartość);`
+zaś na osi Y: ` transform: skewY(wartość);`. Wartość podawana jest w stopniach (`deg`).
 
 Elementy o właściwościach (od lewej) `skewX(10deg)`, `skewX(0)` i `skewX(-10deg)`:
 <div class="rectangle-ch-anim" style="transform: skewX(10deg); width:50px; "></div>
@@ -99,13 +99,10 @@ Elementy o właściwościach (od lewej) `skewY(10deg)`, `skewY(0)` i `skewY(-10d
 <div class="rectangle-ch-anim" style="width:50px;"></div>
 <div class="rectangle-ch-anim" style="transform: skewY(-10deg); width:50px; top: -20px; position: relative;"></div>
 
-## Złożenie przekształceń
-Przekształcenia mogą być kombinacją kilku operacji. 
+## Złożone przekształcenia
+Przekształcenia mogą być kombinacją kilku operacji.
 Jeśli chcielibyśmy, aby nasz element przeskalował się i przesunął wzdłuż osi X, dodajemy do niego poniższą właściwość:
 
 `transform: scale(1.05) translateX(150px);`
 
-Czyli połączenie operacji polega na wymienieniu ich w odpowiedniej kolejności jedna po drugiej, oddzielone spacją.
-
-
-
+Czyli połączenie operacji polega na wymienieniu ich w odpowiedniej kolejności, jedna po drugiej, oddzielonych spacją.

--- a/pl/css-animations/css-transition/README.md
+++ b/pl/css-animations/css-transition/README.md
@@ -45,15 +45,15 @@ a.link:hover {
 }
 ```
 
-Sprawdźmy teraz z czego składa się funkcja `transition`. Zapis `transition: all 0.7s ease-in-out` jest zapisem skrótowym, rozłóżmy go na czynniki pierwsze:
+Sprawdźmy teraz, z czego składa się funkcja `transition`. Zapis `transition: all 0.7s ease-in-out` jest zapisem skrótowym. Rozłóżmy go na czynniki pierwsze:
 
 ```css
-    transition-property: all; 
+    transition-property: all;
     transition-duration: 0.7s;
 	transition-timing-function: ease-in-out;
 
 ```
-- `transition-property` określa nam, na które właściwości CSS wpłynie funkcja przejścia, wartość `all` odpowiada za wszystkie właściwości. Jeśli chcielibyśmy animować tylko kolor tekstu, to wpisalibyśmy `color`, jeśli tło to `background-color` itd. 
+- `transition-property` określa nam, na które właściwości CSS wpłynie funkcja przejścia. Wartość `all` odpowiada za wszystkie właściwości. Jeśli chcielibyśmy animować tylko kolor tekstu, to wpisalibyśmy `color`, jeśli tło to `background-color` itd.
 
 ```css
 	transition-property: color;
@@ -62,9 +62,9 @@ Sprawdźmy teraz z czego składa się funkcja `transition`. Zapis `transition: a
 
 ```
 
-- `transition-duration`, czyli czas trwania przejścia. Im dłuższy, tym bardziej subtelna będzie animacja. Pamiętajmy o dodawaniu jednostek (sekund `s` lub milisekund `ms`).
+- `transition-duration`, czyli czas trwania przejścia. Im dłuższy, tym bardziej subtelna będzie animacja. Pamiętajmy o dodawaniu jednostek – sekund (`s`) lub milisekund (`ms`).
 
-- `transition-timing-function`, czyli sposób w jaki przejście będzie zachodzić. Opisuje to funkcja czasu. W CSS występuje kilka predefiniowanych rodzajów:
+- `transition-timing-function`, czyli sposób, w jaki przejście będzie zachodzić. Opisuje to funkcja czasu. W CSS występuje kilka ich predefiniowanych rodzajów:
 
 ```css
 	transition-timing-function: linear; /* zmiana następuje wg funkcji liniowej */
@@ -75,10 +75,10 @@ Sprawdźmy teraz z czego składa się funkcja `transition`. Zapis `transition: a
 	transition-timing-function: cubic-bezier(); /* przejście następuje wg zadanej fukcji Beziera */
 
 ```
-Jak działają podstawowe funkcje i funkcje Beziera na animowanych elementach możesz <a href="http://cubic-bezier.com/" target="_blank">zobaczyć tutaj</a>.
+Jak działają podstawowe funkcje i funkcje Beziera na animowanych elementach, możesz <a href="http://cubic-bezier.com/" target="_blank">zobaczyć na stronie cubic-bezier.com</a>.
 
 Występuje jeszcze jeden parametr:
-- `transition-delay` – czyli opóźnienie danego przejścia, również podajemy go w jednostkach czasowych. 
+- `transition-delay` – czyli opóźnienie danego przejścia, również podajemy go w jednostkach czasowych.
 
 Pełny zapis funkcji transition wygląda następująco:
 `transition : <transition-property> || <transition-duration> || <transition-timing-function> || <transition-delay>`
@@ -92,15 +92,10 @@ Tutaj przykład animacji z zastosowanym opóźnieniem (`transition-delay`):
 
 > #### Exercise::Ćwiczenie 16
 >
->Pora na ożywienie linków na stronie. Niech każdy link z nawigacji po najechaniu kursorem zmieni kolor (na wartość `#acceb7`).
-> Wykorzystaj funkcję `transition` z dobranymi przez Ciebie parametrami czasu. 
+>Pora na ożywienie linków na stronie. Niech każdy link z nawigacji po najechaniu kursorem zmieni kolor na wartość `#acceb7`.
+> Wykorzystaj funkcję `transition` z dobranymi przez Ciebie parametrami czasu.
 >
 > Zmień kolor tła przycisków po najechaniu kursorem, tak aby osiągnąć poniższy efekt:
 >
 >![Animacja][2]
 [2]: /images/button-animation.gif
-
-
-
-
-

--- a/pl/css-box-model/README.md
+++ b/pl/css-box-model/README.md
@@ -1,8 +1,8 @@
 # Model pudełkowy CSS
 
-*"Życie jest jak pudełko czekoladek - nigdy nie wiesz, co Ci się trafi"* - powiedział kiedyś Forest Gump. Z pisaniem kodu CSS może być podobnie - nigdy nie wiadomo, co się trafi, jeśli nie zna się reguł nim rządzących. Dowiedzieliśmy się właśnie, w jaki sposób przeglądarka decyduje, jakie style nadawać elementom HTML. Kolejnym stopniem wtajemniczenia kodera WWW jest zaznajomienie się z zasadami, w jaki sposób owe elementy są wyświetlane i rozmieszczane na stronie. Tutaj bowiem kryje się najwięcej zabawy!
+"Życie jest jak pudełko czekoladek – nigdy nie wiesz, co Ci się trafi" – powiedział kiedyś Forrest Gump. Z pisaniem kodu CSS może być podobnie – nigdy nie wiadomo, co się trafi, jeśli nie zna się reguł nim rządzących. Dowiedzieliśmy się właśnie, w jaki sposób przeglądarka decyduje, jakie style nadawać elementom HTML. Kolejnym stopniem wtajemniczenia kodera WWW jest zaznajomienie się z zasadami, w jaki sposób owe elementy są wyświetlane i rozmieszczane na stronie. Tutaj bowiem kryje się najwięcej zabawy!
 
-Na początku tej przygody warto zawrzeć bliską znajomość z **modelem pudełkowym**. Model pudełkowy pozwala nam precyzyjnie określić wymiary elementu HTML na stronie. Każdy z elementów na stronie można bowiem potraktować jako prostokąt o określonych wymiarach, który może posiadać wypełnienie (*padding*), obramowanie (*border*) oraz margines (*margin*). 
+Na początku tej przygody warto zawrzeć bliską znajomość z <b>modelem pudełkowym</b>. Model pudełkowy pozwala nam precyzyjnie określić wymiary elementu HTML na stronie. Każdy z elementów na stronie można bowiem potraktować jako prostokąt o określonych wymiarach, który może posiadać wypełnienie (<i>padding</i>), obramowanie (<i>border</i>) oraz margines (<i>margin</i>).
 
 ![Model pudełkowy][1]
 
@@ -72,7 +72,7 @@ Albo zastosować zapis skrótowy:
 padding: 10px 15px 20px 12px;
 ```
 
-Żeby nie pogubić się w zapisie skrótowym spróbujcie zapamiętać, że wartości wypełnienia zapisujemy zgodnie z ruchem wskazówek zegara, zaczynając od góry. Możecie również wykorzystać do tego kolejność liter w słowie `TRouBLe` - `Top Right Bottom Left`.
+Żeby nie pogubić się w zapisie skrótowym, spróbujcie zapamiętać, że wartości wypełnienia zapisujemy zgodnie z ruchem wskazówek zegara, zaczynając od góry. Możecie również wykorzystać do tego kolejność liter w słowie `TRouBLe` – `Top Right Bottom Left`.
 
 ### Obramowanie (`border`)
 
@@ -110,7 +110,7 @@ border-color: salmon;
 
 ### Margines (`margin`)
 
-Margines jest to odległość między krawędzią (ramką) elementu a innym, sąsiadującym elementem. Marginesy definiujemy podobnie, jak wypełnienie - możemy użyć również zapisu skrótowego.
+Margines jest to odległość między krawędzią (ramką) elementu a innym, sąsiadującym elementem. Marginesy definiujemy podobnie, jak wypełnienie. Możemy użyć również zapisu skrótowego.
 
 ```html
 <div class="box-of-chocolates">
@@ -135,10 +135,10 @@ Margines jest to odległość między krawędzią (ramką) elementu a innym, są
   </div>
 </div>
 
-Co ciekawe, marginesy mogą również przybierać wartości **ujemne**, w przeciwieństwie do wypełnień i ramek, które to powinny zawsze przyjmować wartości dodatnie (ujemne w tych przypadkach zostaną zignorowane przez przeglądarkę).
+Co ciekawe, marginesy mogą również przybierać <b>wartości ujemne</b>, w przeciwieństwie do wypełnień i ramek, które to powinny zawsze przyjmować <b>wartości dodatnie</b> (ujemne w tych przypadkach zostaną zignorowane przez przeglądarkę).
 
 
-To, jak model pudełkowy został wyliczony przez przeglądarkę, możemy podejrzeć w narzędziach deweloperskich w sekcji dotyczącej CSS w zakładce *Computed* (dla Chrome).
+To, jak model pudełkowy został wyliczony przez przeglądarkę, możemy podejrzeć w narzędziach deweloperskich w sekcji dotyczącej CSS w zakładce <i>Computed</i> (w Chrome).
 
 ![Podgląd modelu pudełkowego w narzędziach deweloperskich][2]
 
@@ -148,7 +148,7 @@ To, jak model pudełkowy został wyliczony przez przeglądarkę, możemy podejrz
 
 Czy wiedzieliście, że w CSS możecie określić długość linii tekstu w liczbie znaków? Tak, jest [wiele opcji do wyboru, nie tylko piksele](https://developer.mozilla.org/en/docs/Web/CSS/length). Te przeróżne jednostki przydają się nam do określenia wymiarów elementów (model pudełkowy!), a także rozmiaru fontu. Zapoznajmy się zatem z kilkoma najpopularniejszymi.
 
-- `%`, czyli procenty. Możemy określać wymiary elementu w procentach - będą one wtedy wyrażały te wymiary względem rodzica elementu (czyli kontenera, w którym dany element się znajduje). Procenty są przydatne, jeśli chcemy uzyskać elastyczny layout, którego elementy zmieniają wymiary płynnie wraz ze skalowaniem okna.
+- `%`, czyli procenty. Możemy określać wymiary elementu w procentach. Będą one wtedy wyrażały te wymiary względem rodzica elementu (czyli kontenera, w którym dany element się znajduje). Procenty są przydatne, jeśli chcemy uzyskać elastyczny layout, którego elementy zmieniają wymiary płynnie wraz ze skalowaniem okna.
 
 ```css
 .fluid-container {
@@ -156,7 +156,7 @@ Czy wiedzieliście, że w CSS możecie określić długość linii tekstu w licz
 }
 ```
 
-- `em` - podczas, gdy piksele reprezentują fizyczne piksele na ekranie i są jednostką bezwzględną, `em` jest jednostką względną i odnosi się do rozmiaru fontu rodzica elementu. Jeśli nadamy elementowi rozmiar lub wielkość fontu równą `1em`, będzie to oznaczało, że wymiar ten jest równy rozmiarowi fontu jego bezpośredniego rodzica. Spójrzmy na przykład:
+- `em` – podczas, gdy piksele reprezentują fizyczne piksele na ekranie i są jednostką bezwzględną, `em` jest jednostką względną i odnosi się do rozmiaru fontu rodzica elementu. Jeśli nadamy elementowi rozmiar lub wielkość fontu równą `1em`, będzie to oznaczało, że wymiar ten jest równy rozmiarowi fontu jego bezpośredniego rodzica. Spójrzmy na przykład:
 
 ```html
 <div class="grandpa">
@@ -174,12 +174,12 @@ Czy wiedzieliście, że w CSS możecie określić długość linii tekstu w licz
 .grandpa {
   font-size: 1.5em; /* 16px */
 }
- 
+
 .father {
   font-size: 1.5em; /* 1.5 * 16px = 24px */
 }
- 
- 
+
+
 .son {
   font-size: 1.5em; /* 1.5 * 24px = 36px */
 }
@@ -197,9 +197,9 @@ Czy wiedzieliście, że w CSS możecie określić długość linii tekstu w licz
   </div>
 </div>
 
-Widzicie więc, że pomimo, iż każdy z elementów posiada identyczną wartość `font-size` - `1.5em`, wynikowe wielkości się różnią. Na początku może się Wam to wydawać mało intuicyjne, jednak w miarę im będziecie się stawać bardziej zaawansowani, odkryje się przed Wami bogactwo zastosowań dla `em`.
+Widzicie więc, że pomimo, iż każdy z elementów posiada identyczną wartość `font-size` – `1.5em` – wynikowe wielkości się różnią. Na początku może się Wam to wydawać mało intuicyjne, jednak w miarę jak będziecie się stawać bardziej zaawansowani, odkryje się przed Wami bogactwo zastosowań dla `em`.
 
-- `rem` - również jest to jednostka względna. Jej nazwę można rozwinąć jako "*root* `em`". Działa więc podobnie do `em` z tą różnicą, że wartość wynikowa jest obliczana względem **korzenia** (*root*) drzewa dokumentu HTML. Zwykle oznacza to, że wartości `rem` obliczane są względem wielkości fonta zadeklarowanego wewnątrz selektora `html`.
+- `rem` – również jest to jednostka względna. Jej nazwę można rozwinąć jako "<i>root</i> `em`". Działa więc podobnie do `em` z tą różnicą, że wartość wynikowa jest obliczana względem <b>korzenia</b> (<i>root</i>) drzewa dokumentu HTML. Zwykle oznacza to, że wartości `rem` obliczane są względem wielkości fonta zadeklarowanego wewnątrz selektora `html`.
 
 ```html
 <section class="outer">
@@ -216,17 +216,17 @@ Widzicie więc, że pomimo, iż każdy z elementów posiada identyczną wartoś�
 html {
   font-size: 16px;
 }
- 
+
 .outer {
   font-size: 1.5rem; /* 1.5 * 16px = 24px */
 }
- 
+
 .inner {
   font-size: 2rem; /* 2 * 16px = 32px */
 }
 ```
 
-- `vw` (ang. <i>vieport witdh</i>) oraz `vh` (ang. <i>viewport height</i>). Są to jednostki dotyczące wysokości i szerokości **okna przeglądarki**. `1vw` oznacza `1/100` szerokości okna, a `1vh` - `1/100` wysokości okna.
+- `vw` (ang. <i>vieport witdh</i>) oraz `vh` (ang. <i>viewport height</i>). Są to jednostki dotyczące wysokości i szerokości <b>okna przeglądarki</b>. `1vw` oznacza `1/100` szerokości okna, a `1vh` – `1/100` wysokości okna.
 
 ```css
 .scalable-element {
@@ -238,7 +238,7 @@ html {
 
 > #### Exercise::Ćwiczenie 12* (dla chętnych)
 >
-> Jeśli masz ochotę zakodować nowy layout to ćwiczenie jest dla Ciebie! Wykorzystaj zdobytą dotychczasową wcześniej wiedzę i postaraj się stworzyć stronę, wizualnie zbliżoną do poniższego projektu. 
+> Jeśli masz ochotę zakodować nowy layout, to ćwiczenie jest dla Ciebie! Wykorzystaj zdobytą dotychczasową wcześniej wiedzę i postaraj się stworzyć stronę wizualnie zbliżoną do poniższego projektu.
 >
 > ![Layout Moodly](/resources/moodly-assets/moodly-layout.png "Layout Moodly")
 >
@@ -246,7 +246,7 @@ html {
 
 >Być może nasuwa Ci się pytanie jak dołączać obrazki jako tło? Odpowiedź znajdziesz pod ćwiczeniem.
 
-> Do pozostałych elementów użyj znanych tagów i właściwości CSS m.in. 
+> Do pozostałych elementów użyj znanych tagów i właściwości CSS m.in.
 >
 >- `height` i `width` (do zdefiniowania rozmiarów),
 >- `text-align` (do wycentrowania tekstu),
@@ -255,26 +255,26 @@ html {
 >- świeżo zdobytej wiedzy o modelu pudełkowym.
 
 
-> Nie przejmuj się, jeśli nie uda Ci się wiernie odwzorować layoutu. Wrócimy do niego po kolejnych zajęciach, kiedy nauczymy się nowych rzeczy :) 
+> Nie przejmuj się, jeśli nie uda Ci się wiernie odwzorować layoutu. Wrócimy do niego po kolejnych zajęciach, kiedy nauczymy się nowych rzeczy :)
 > Poniżej znajdziecie jeszcze kilka przydatnych informacji, w tym właściwości CSS, które pomogą Wam w tym ćwiczeniu.
 
 ### Inne właściwości CSS
 
 #### Obrazek jako tło `background-image`
 
-Żeby wypełnić dany element (sekcje, kontener, czy nawet całą zawartość strony, czyli `<body>`) stosujemy właściwość:
+Żeby wypełnić dany element (sekcje, kontener, czy nawet całą zawartość strony, czyli `<body>`) obrazkowym tłem, stosujemy właściwość:
 ```css
   background-image: url('tutaj podaję ścieżkę do obrazka');
 ```
 
-Przykładowo: 
+Przykładowo:
 ```
 section {
-  background-image: url('./images/background.jpg'); 
+  background-image: url('./images/background.jpg');
 }```
 Pamiętajcie o prawidłowym podaniu względnej ścieżki do obrazka.
 
-Tło może przyjmować jeszcze wiele ciekawych właściwości, które <a href="https://developer.mozilla.org/en/docs/Web/CSS/background-image" target="_blank">znajdziesz tutaj</a>.
+Tło może przyjmować jeszcze wiele ciekawych właściwości, które <a href="https://developer.mozilla.org/en/docs/Web/CSS/background-image" target="_blank">znajdziesz na MDN</a>.
 
 Warto potestować różne opcje dla rozmiaru tła, czyli `background-size`
 ```css
@@ -286,7 +286,7 @@ Warto potestować różne opcje dla rozmiaru tła, czyli `background-size`
 Sprawdźcie jak zmienia się tło pod wpływem zmiany szerokości okna przeglądarki.
 
 #### Stylowanie listy
-Pewnie zastanawiacie się jak pozbyć się kropeczek przy elementach listy (`<ul>`). 
+Pewnie zastanawiacie się jak pozbyć się kropeczek przy elementach listy (`<ul>`).
 Służy do tego właściwość:
 ```css
   ul.list{
@@ -297,11 +297,11 @@ Dzięki wartości `none` usunięte zostaną domyślne symbole oznaczające eleme
 
 
 
-###`<div>`, czyli kontener 
+###`<div>`, czyli kontener
 <a href="../html-document-structure/index.html">W rozdziale 7.</a> wspomnieliśmy o znaczniku `<div>`, czyli elemencie blokowym. Znacznik ten bardzo często służy nam przy budowaniu layoutów, kiedy żaden z innych tagów nie pasuje znaczeniowo do zawartości, którą umieszczamy.
 
 Najlepiej zobrazuje to poniższy przykład.
-Wyobraźmy sobie, że na naszej stronie występuje sekcja "Autorzy", w której zawartych jest kilka kontenerów ze zdjęciami i opisami osób. 
+Wyobraźmy sobie, że na naszej stronie występuje sekcja "Autorzy", w której zawartych jest kilka kontenerów ze zdjęciami i opisami osób.
 Jak by wyglądał kod HTML takiego rozwiązania?
 
 ```html
@@ -332,8 +332,7 @@ Jak by wyglądał kod HTML takiego rozwiązania?
 </section>
 ```
 
-Tak jak widzcie sylwetka każdego autora, zosała umieszczona w konterze, jakim jest `<div>`. 
+Tak jak widzcie, sylwetka każdego autora zosała umieszczona w konterze, jakim jest `<div>`.
 Znacznik ten zatem umożliwia nam powiązać elementy w dany sposób. Dzięki czemu zawartość staje się jeszcze bardziej uporządkowana, a my możemy wykorzystać CSS-ową klasę kontenera i przypisać mu konkretne style.
 
-Podglądając kod innych stron w sieci, zauważycie, że `<div>` jest badzo popularnym tagiem. Jednak pamiętajcie, że dla treści, których znaczenie może być precyzyjniej określone, warto stosować konkretne tagi np.`<article>` dla artykułów, `<footer>` dla stopki, `<aside>` dla elementów pobocznych, `<nav>` dla nawigacji itd.
-
+Podglądając kod innych stron w sieci, zauważycie, że `<div>` jest badzo popularnym tagiem. Jednak pamiętajcie, że dla treści, których znaczenie może być precyzyjniej określone, warto stosować konkretne tagi, np.`<article>` dla artykułów, `<footer>` dla stopki, `<aside>` dla elementów pobocznych, `<nav>` dla nawigacji itd.

--- a/pl/css-cascade/README.md
+++ b/pl/css-cascade/README.md
@@ -1,26 +1,26 @@
 # Kaskadowość i dziedziczenie w CSS
 
-Właśnie postawiliście swoje pierwsze kroki w stylowaniu dokumentu HTML - gratulujemy! Z pewnością rozbudziło to Wasze apetyty na więcej, ale też zrodziło nieco pytań i wątpliwości. 
+Właśnie postawiliście swoje pierwsze kroki w stylowaniu dokumentu HTML – gratulujemy! Z pewnością rozbudziło to Wasze apetyty na więcej, ale też zrodziło nieco pytań i wątpliwości.
 
-W [rozdziale 8](../css-code/README.md) - przy okazji pokazania, jak dołączać arkusze stylów do strony - zwróciliśmy Waszą uwagę na kolejność dołączania plików. Niektórym z Was już pewnie w tamtym momencie zaświtało, że style dla naszej strony mogą pochodzić z różnych źródeł.
+W [rozdziale 8](../css-code/README.md), przy okazji pokazania, jak dołączać arkusze stylów do strony, zwróciliśmy Waszą uwagę na kolejność dołączania plików. Niektórym z Was już pewnie w tamtym momencie zaświtało, że style dla naszej strony mogą pochodzić z różnych źródeł.
 
 ## Kaskada CSS
 
 Co to znaczy, że style pochodzą z różnych źródeł? Czy na wygląd naszej strony wpływają też arkusze stylów z nieznanego nam miejsca, które są poza naszą kontrolą?
 
-W gruncie rzeczy dokładnie tak się dzieje. Oprócz stylów, nad którymi pracujemy samodzielnie, na elementy na stronie mają wpływ również **domyślne style przeglądarki** (ang. *user agent stylesheets*) oraz **style zdefiniowane przez użytkownika**. Te pierwsze zdążyliście już zobaczyć w akcji podczas tworzenia "gołego" pliku HTML. Dokładnie - gdyby nie domyślne style, które nadaje przeglądarka, zawartość strony pomimo zastosowania różnych znaczników wyglądałaby jak jednolity blok zwykłego tekstu. Dzięki domyślnym stylom przeglądarki, nawet w wypadku, kiedy nie zostanie dołączony kod CSS stworzony przez autora strony, dla użytkownika wszystko będzie czytelne.
+W gruncie rzeczy dokładnie tak się dzieje. Oprócz stylów, nad którymi pracujemy samodzielnie, na elementy na stronie mają wpływ również <b>domyślne style przeglądarki</b> (ang. <i>user agent stylesheets</i>) oraz <b>style zdefiniowane przez użytkownika</b>. Te pierwsze zdążyliście już zobaczyć w akcji podczas tworzenia "gołego" pliku HTML. Dokładnie, gdyby nie domyślne style, które nadaje przeglądarka, zawartość strony pomimo zastosowania różnych znaczników wyglądałaby jak jednolity blok zwykłego tekstu. Dzięki domyślnym stylom przeglądarki, nawet w wypadku, kiedy nie zostanie dołączony kod CSS stworzony przez autora strony, dla użytkownika wszystko będzie czytelne.
 
 > #### Important::Ważne
 >
 > Warto w tym momencie zauważyć, że domyślne style różnych przeglądarek (Chrome, Firefox, Internet Explorer, Safari, itp.) różnią się nieco od siebie. W związku z tym, zanim zaczniemy aplikować własne style do naszego dokumentu, warto zadbać, aby zniwelować te różnice.
 >
-> Brzmi jak wyzwanie? Na szczęście, jak w wielu przypadkach w programowaniu, istnieje na to gotowe rozwiązanie. Społeczność programistów WWW jest bardzo duża oraz chętnie dzieli się wiedzą i doświadczeniem. 
+> Brzmi jak wyzwanie? Na szczęście, jak w wielu przypadkach w programowaniu, istnieje na to gotowe rozwiązanie. Społeczność programistów WWW jest bardzo duża oraz chętnie dzieli się wiedzą i doświadczeniem.
 >
-> W sieci można znaleźć sporo rozwiązań - do najpopularniejszych należą [`normalize.css`](https://necolas.github.io/normalize.css/) i [`reset.css`](http://meyerweb.com/eric/tools/css/reset/). Są to po prostu gotowe arkusze stylów które należy dołączyć do naszej strony **przed** własnymi stylami. "Wyrównują" one wszelkie różnice w związku z czym nie musimy już sobie zawracać głowy z większością różnic między przeglądarkami.
+> W sieci można znaleźć sporo rozwiązań - do najpopularniejszych należą [`normalize.css`](https://necolas.github.io/normalize.css/) i [`reset.css`](http://meyerweb.com/eric/tools/css/reset/). Są to po prostu gotowe arkusze stylów, które należy dołączyć do naszej strony **przed** własnymi stylami. "Wyrównują" one wszelkie różnice pomiędzy domyślnymi stylami w różnych przeglądarkach, w związku z czym nie musimy już sobie zawracać głowy większością różnic między przeglądarkami.
 >
 > `normalize.css` i `reset.css` nieco się od siebie różnią w koncepcji działania:
-> - `reset.css`, jak wskazuje nazwa, resetuje wszystkie domyślne style, w związku z czym wszystkie elementy (nagłówki, paragrafy, itp.) po jego zastosowaniu wyglądają jednakowo.
-> - `normalize.css` normalizuje style - po zastosowaniu tego arkusza wciąż będzie widoczna np.  hierarchia nagłówków. Nasze elementy HTML wciąż będą wizualnie rozróżnialne.
+> - `reset.css`, jak wskazuje nazwa, resetuje wszystkie domyślne style, w związku z czym wszystkie elementy (nagłówki, akapity, itp.) po jego zastosowaniu wyglądają jednakowo.
+> - `normalize.css` normalizuje style – po zastosowaniu tego arkusza wciąż będzie widoczna np. hierarchia nagłówków. Nasze elementy HTML wciąż będą wizualnie rozróżnialne.
 >
 > Przypomnijmy jeszcze na koniec, że powyższe "normalizujące" arkusze stylów należy dołączać do naszego dokumentu HTML **w pierwszej kolejności**.
 
@@ -29,26 +29,26 @@ Na początku pracy ze stroną polecamy dołączyć do dokumentu style niwelując
 > #### Exercise::Ćwiczenie 10
 >
 > - Przejdź do folderu `planty`.
-> - Przejdź do strony [`normalize.css`](https://necolas.github.io/normalize.css/) i kilknij *Download* (*Pobierz*). Skopiuj zawartość.
+> - Przejdź do strony [`normalize.css`](https://necolas.github.io/normalize.css/) i kilknij <i>Download</i> (<i>Pobierz</i>). Skopiuj zawartość.
 > - Utwórz w folderze `planty/styles` plik o nazwie `normalize.css` i wklej do niego skopiowane przed chwilą style.
 > - Podłącz arkusz stylów `normalize.css` do `index.html` uważając na to, aby był zalinkowany **przed** Twoim własnym arkuszem stylów.
 
-Style zdefiniowane przez użytkownika to dość rzadki przypadek. Warto jednak w tym momencie zauważyć, że istnieje taka możliwość, aby CSS został zdefiniowany po stronie użytkownika. Dobrym przykładem takich arkuszy stylów są te stosowane np. przez wtyczki przełączające stronę w tryb polepszonej czytelności (przydatny do czytania artykułów - usuwa z pola widzenia wszystkie "rozpraszacze").
+Style zdefiniowane przez użytkownika to dość rzadki przypadek. Warto jednak w tym momencie zauważyć, że istnieje taka możliwość, aby CSS został zdefiniowany po stronie użytkownika. Dobrym przykładem takich arkuszy stylów są te stosowane np. przez wtyczki przełączające stronę w tryb polepszonej czytelności (przydatny do czytania artykułów – usuwa z pola widzenia wszystkie "rozpraszacze").
 
-Mając do dyspozycji style z różnych źródeł, w jaki sposób przeglądarka decyduje, które z reguł zastosuje dla danego elementu? Skrót CSS w języku angielskim rozwija się jako *Cascading StyleSheets*, co oznacza *kaskadowe arkusze stylów*. 
+Mając do dyspozycji style z różnych źródeł, w jaki sposób przeglądarka decyduje, które z reguł zastosuje dla danego elementu? Skrót CSS w języku angielskim rozwija się jako <i>Cascading StyleSheets</i>, co oznacza <i>kaskadowe arkusze stylów</i>.
 
-**Kaskada** jest właściwością CSS, która decyduje, w jaki sposób określić ważność stylów pochodzących z różnych źródeł. Kolejność kaskady (zaczynając od styli o najmniejszej ważności):
+<b>Kaskada</b> jest właściwością CSS, która decyduje, w jaki sposób określić ważność stylów pochodzących z różnych źródeł. Kolejność kaskady (zaczynając od stylów o najmniejszej ważności):
 
-1. Zwykłe style domyślne przeglądarki
-2. Domyślne style przeglądarki z `!important`
-3. Zwykłe style zdefiniowane przez użytkownika
-4. Zwykłe style zdefiniowane przez programistę strony
-5. Style zdefiniowane przez programistę strony z użyciem `!important`
-6. Style zdefiniowane po stronie użytkownika z użyciem `!important`
+1. Zwykłe style domyślne przeglądarki.
+2. Domyślne style przeglądarki z `!important`.
+3. Zwykłe style zdefiniowane przez użytkownika.
+4. Zwykłe style zdefiniowane przez programistę strony.
+5. Style zdefiniowane przez programistę strony z użyciem `!important`.
+6. Style zdefiniowane po stronie użytkownika z użyciem `!important`.
 
-Co to takiego jest `!important` dowiemy się niebawem, już w kolejnym rozdziale.
+Czym jest `!important`, dowiemy się niebawem, już w kolejnym rozdziale.
 
-## Dziedziczenie styli
+## Dziedziczenie stylów
 
 Wykonując ćwiczenie 8 zauważyliście, że udało Wam się pokolorować tekst na całej stronie używając tylko selektora `body`.
 
@@ -58,15 +58,15 @@ body {
 }
 ```
 
-Mimo, że nie odwoływaliśmy się *bezpośrednio* do poszczególnych paragrafów i nagłówków za pomocą selektorów, w pewien magiczny sposób uzyskały one ten sam kolor, co `body`.
+Mimo, że nie odwoływaliśmy się <i>bezpośrednio</i> do poszczególnych akapitów i nagłówków za pomocą selektorów, w pewien magiczny sposób uzyskały one ten sam kolor co `body`.
 
-Cechę CSS, dzięki której wartości poszczególnych właściwości są przekazywane od elementu rodzica do elementu dziecka nazywamy **dziedziczeniem**. Zademonstrujmy to na przykładzie:
+Cechę CSS, dzięki której wartości poszczególnych właściwości są przekazywane od elementu rodzica do elementu dziecka, nazywamy <b>dziedziczeniem</b>. Zademonstrujmy to na przykładzie:
 
 ```html
 <h1>Jestem przykładowym nagłówkiem</h1>
 
 <div class="inheritance-example">
-  <p>Jestem paragrafem tekstu, który odziedziczy kolor po rodzicu.</p>
+  <p>Jestem akapitem tekstu, który odziedziczy kolor po rodzicu.</p>
   <p>Ja również zostanę pokolorowany.</p>
 </div>
 
@@ -82,13 +82,13 @@ Cechę CSS, dzięki której wartości poszczególnych właściwości są przekaz
 <div class="example-wrapper">
   <h1>Jestem przykładowym nagłówkiem</h1>
   <div style="color:deeppink;">
-    <p style="color:deeppink;">Jestem paragrafem tekstu, który odziedziczy kolor po rodzicu.</p>
+    <p style="color:deeppink;">Jestem akapitem tekstu, który odziedziczy kolor po rodzicu.</p>
     <p style="color:deeppink;">Ja również zostanę pokolorowany.</p>
   </div>
   <p>Jestem przykładowym tekstem, który nie zostanie pokolorowany.</p>
 </div>
 
-Stałoby się podobnie, jeśli nadalibyśmy rodzicowi określony kolor tła - wtedy wszystkie dzieci automatycznie uzyskałyby taki sam kolor. Jednak nie wszystkie właściwości CSS są dziedziczone. Nie dzieje się tak na przykład w przypadku ramek, co jest zresztą dość intuicyjne. Spróbujcie sobie tylko wyobrazić, jakby wyglądałby efekt, gdyby dodano obramowanie do `body` a pozostałe elementy dziedziczyły tę właściwość! Poniżej podajemy, które ze znanych już Wam właściwości są dziedziczone, a które nie.
+Nie wszystkie właściwości CSS są dziedziczone. Nie dzieje się tak na przykład w przypadku ramek, co jest zresztą dość intuicyjne. Spróbujcie sobie tylko wyobrazić, jakby wyglądałby efekt, gdyby dodano obramowanie do `body` a pozostałe elementy dziedziczyły tę właściwość! Poniżej podajemy, które ze znanych już Wam właściwości są dziedziczone, a które nie.
 
 Właściwości, które są dziedziczone:
 
@@ -107,4 +107,3 @@ Właściwości, które nie są dziedziczone:
 - `padding`
 - `width`
 - `height`
-

--- a/pl/css-code/README.md
+++ b/pl/css-code/README.md
@@ -18,18 +18,18 @@ p {
 }
 ```
 
-W powyższy sposób ustawiamy kolor tekstu wszystkich paragrafów na stronie na niebieski. Z tego przykładu łatwo wysnuć wniosek, że za pomocą CSS-a możemy wybierać elementy podając nazwy znaczników. Nie jest to jednak jedyny sposób - zapoznajmy się z kilkoma podstawowymi rodzajami **selektorów CSS**.
+W powyższy sposób ustawiamy niebieski kolor tekstu dla wszystkich akapitów na stronie. Z tego przykładu łatwo wysnuć wniosek, że za pomocą CSS-a możemy wybierać elementy podając nazwy znaczników. Nie jest to jednak jedyny sposób. Zapoznajmy się z kilkoma podstawowymi rodzajami <b>selektorów CSS</b>.
 
 ## Podstawowe selektory
 
 Elementy na stronie można wybierać na bardzo różne sposoby. W tym rodziale poznamy podstawowe i najczęściej używane selektory CSS, czyli:
 
-- nazwa tagu (`tagname`)
-- klasa (`.classname`)
-- ID (`#idname`)
-- atrybut (`[attr=value]`)
+- nazwę tagu (`tagname`),
+- klasę (`.classname`),
+- ID (`#idname`),
+- atrybut (`[attr=value]`).
 
-Selektor wybierający element na podstawie tagu już przed chwilą widzieliśmy. Patrząc na selektory ID oraz atrybutu zapewne zaczyna już coś Wam świtać - oznacza to, że możemy wybierać elementy również bazując na wartościach ich atrybutów `id` oraz obecności innych atrybutów. Jedyny rodzaj, który pewnie wydaje się w tej chwili tajemniczy to *klasa*.
+Selektor wybierający element na podstawie tagu już przed chwilą widzieliśmy. Patrząc na selektory ID oraz atrybutu zapewne zaczyna już coś Wam świtać. Oznacza to, że możemy wybierać elementy również bazując na wartościach ich atrybutów `id` oraz obecności innych atrybutów. Jedyny rodzaj, który pewnie wydaje się w tej chwili tajemniczy to <i>klasa</i>.
 
 ### Klasa
 
@@ -41,7 +41,7 @@ Przyjrzyjmy się przykładowemu elementowi strony:
 
 Obok znanych już Wam atrybutów `type` oraz `id` pojawił się nowy: `class`. Jest on bardzo ważny w kontekście stylowania.
 
-W zasadzie jedynym celem atrybutu `class` jest nadanie naszemu elementowi *identyfikatora*, który będzie służył jako selektor. Pewnie pomyślicie teraz *"ale przecież on ma już identyfikator `id`!"*. Słusznie, jednak wartość atrybutu `class` nie musi być unikalna w zakresie dokumentu. Tę samą wartość możemy nadać więcej niż jednemu elementowi, nie muszą też być one tego samego rodzaju.
+W zasadzie jedynym celem atrybutu `class` jest nadanie naszemu elementowi <i>identyfikatora</i>, który będzie służył jako selektor. Pewnie pomyślicie teraz "ale przecież on ma już identyfikator `id`!". Słusznie, jednak wartość atrybutu `class` nie musi być unikalna w zakresie dokumentu. Tę samą wartość możemy nadać więcej niż jednemu elementowi, nie muszą też być one tego samego rodzaju.
 
 ```html
 <body>
@@ -93,15 +93,15 @@ Nadajmy tekstowi w naszej kontrolce kolor czerwony, odnosząc się do niego po `
 }
 ```
 
-Przypomnijmy, że w jednym dokumencie wartości atrybutu `id` powinny być unikalne. W związku z tym style zawarte wewnątrz tego selektora nie są zbyt reużywalne - możemy je zastosować tylko dla jednego, konkretnego elementu na stronie.
+Przypomnijmy, że w jednym dokumencie wartości atrybutu `id` powinny być unikalne. W związku z tym style zawarte wewnątrz tego selektora nie są zbyt reużywalne – możemy je zastosować tylko dla jednego, konkretnego elementu na stronie.
 
 ### Atrybut
 
-Stylować można również elementy zawierające konkretny atrybut. Dobrym przykładem jest np. tag `<input type="text">`. W tym wypadku deklaracja CSS będzie dotyczyła kontrolek `input` typu text. 
+Stylować można również elementy zawierające konkretny atrybut. Dobrym przykładem jest np. tag `<input type="text">`. W tym wypadku deklaracja CSS będzie dotyczyła kontrolek `input` typu text.
 
 ```css
 input[type="text"] {
-  border: 2px solid blue; 
+  border: 2px solid blue;
 }
 ```
 W wyniku powyższego kodu do kontrolki zostanie dodana ramka o grubości 2px i kolorze niebieskim.
@@ -121,14 +121,14 @@ border-color: blue;
 
 ## Podstawowe właściwości CSS i ich wartości
 
-CSS umożliwia przypisanie do HTML-owych elementów całej palety różnych właściwości - od koloru tekstu, tła, przez zastosowanie dowolnego kroju pisma, dodania cieniowania, gradientu  aż do definiowania pozycji. W tym rozdziale zajmiemy się tymi najbardziej podstawowymi. Inne poznamy na kolejnych zajęciach. Wszystkich chętnych, którzy już teraz chcą zagłębić się w temacie CSS-owych właściwości zapraszamy na <a href="http://www.quackit.com/css/properties/" target="_blank">tę stronę</a>, choć podobnych źródeł w tym temacie znajdziecie jeszcze więcej.
+CSS umożliwia przypisanie do HTML-owych elementów całej palety różnych właściwości: od koloru tekstu, tła, przez zastosowanie dowolnego kroju pisma, dodania cieniowania, gradientu, aż do definiowania pozycji. W tym rozdziale zajmiemy się tymi najbardziej podstawowymi. Inne poznamy na kolejnych zajęciach. Wszystkich chętnych, którzy już teraz chcą zagłębić się w temacie CSS-owych właściwości, zapraszamy na <a href="http://www.quackit.com/css/properties/" target="_blank">stronę QuackIt.com</a>, choć podobnych źródeł w tym temacie znajdziecie jeszcze więcej.
 
 ### Kolorowanie tekstu (`color`)
 
-Służy nam do tego właściwość `color`. Najczęściej wartości kolorów definiuje się w kodzie **heksadecymalnym** (**hex**), czyli szestnastkowym z charakterystycznym znakiem `#`. Kody te pobiera się z tzw. <i>color pickerów</i>, np. <a href="http://htmlcolorcodes.com/" target="_blank">tutaj</a>. w programach graficznych lub innych narzędzi. Jeśli zainteresowaliście się kodem heksadecymalnym więcej do poczytania <a href="https://pl.wikipedia.org/wiki/Kolory_w_Internecie#Zapis_szesnastkowy">tutaj</a>.
+Służy nam do tego właściwość `color`. Najczęściej wartości kolorów definiuje się w kodzie <i>heksadecymalnym</i> (<i>hex</i>), czyli szestnastkowym z charakterystycznym znakiem `#`. Kody te pobiera się z tzw. <i>color pickerów</i>, np. <a href="http://htmlcolorcodes.com/" target="_blank">na stronie HTMLColorCodes.com</a>, w programach graficznych lub innych narzędziach. Jeśli zainteresowaliście się kodem heksadecymalnym, więcej do poczytania <a href="https://pl.wikipedia.org/wiki/Kolory_w_Internecie#Zapis_szesnastkowy">na Wikipedii</a>.
 
 W CSS istnieją też [predefiniowane kolory](https://developer.mozilla.org/en/docs/Web/CSS/color_value) które możemy przypisać do elementów po prostu podając ich nazwę, np. `color: blue;` lub `color: salmon;`.
-Poza kodem heksadecymalnym i predefiniowanymi nazwami, możemy także przypisywać kolory poprzez zapis **rgb** (kanały <i>red, green</i> oraz <i>blue</i>), hsl (<i>**hue**</i> - barwa, <i>saturation</i> - nasycenie, <i>lightness</i> - jasność) czy nawet **rgba** i **hsla** (z uwzględnionym kanałem <i>alfa</i>, czyli kanałem odpowiadającym za stopień przezroczystości). 
+Poza kodem heksadecymalnym i predefiniowanymi nazwami, możemy także przypisywać kolory poprzez zapis <b>rgb</b> (kanały <i>red</i>, <i>green</i> oraz <i>blue</i>), hsl (<i>hue</i> – barwa, <i>saturation</i> – nasycenie, <i>lightness</i> – jasność) czy nawet <b>rgba</b> i <b>hsla</b> (z uwzględnionym kanałem <i>alfa</i>, czyli kanałem odpowiadającym za stopień przezroczystości).
 
 ```css
 p {
@@ -137,16 +137,16 @@ p {
 }
 ```
 
-<p style="color: #f14b5c;">To jest paragraf o kolorze pomarańczowym.</p>
+<p style="color: #f14b5c;">To jest akapit o kolorze pomarańczowym.</p>
 
 
 > #### Important::Ważne
 >
-> W CSS-owych kolorach występuje również wartość `transparent`, czyli przezroczysty. 
+> W CSS-owych kolorach występuje również wartość `transparent`, czyli przezroczysty.
 
 
 ### Kolorowanie tła (`background-color`)
-Służy do tego właściwość: `background-color: #fff;`
+Służy do tego właściwość `background-color`, np.:
 
 ```css
 p {
@@ -159,7 +159,7 @@ p {
 > #### Important::Ważne
 >
 > Zauważyliście już z pewnością, że wewnątrz kodu danego selektora możemy podać wartości więcej niż jednej właściwości.
-> Pamiętajcie o tym, aby każdą linijkę kodu z deklaracją właściwości kończyć średnikiem - `;`.
+> Pamiętajcie o tym, aby każdą linijkę kodu z deklaracją właściwości kończyć średnikiem – `;`.
 > ```css
 /* deklaracja poprawna */
 .good {
@@ -177,16 +177,16 @@ p {
 ```
 > Niedomknięcie linii średnikiem spowoduje błąd w interpretacji arkusza stylów i w takiej sytuacji przeglądarka zignoruje źle zapisane deklaracje.
 >
-> Żeby uniknąć sytuacji, kiedy łamiecie sobie głowę zastanawiając się *"czemu mój kod nie działa?"*, bądźcie bardzo skrupulatni w domykaniu linii średnikami!
+> Żeby uniknąć sytuacji, kiedy łamiecie sobie głowę zastanawiając się "czemu mój kod nie działa?", bądźcie bardzo skrupulatni w domykaniu linii średnikami!
 
 ### Obramowanie (`border`)
 
-Za obramowanie odpowiada właściwość `border`, której przypisać możemy grubość, rodzaj / styl linii (przerywana, ciągła, kropkowana) i kolor. Przy nadawaniu wartości powinna być zachowana powyższa kolejność, czyli: grubość, styl, kolor:
+Za obramowanie odpowiada właściwość `border`, której przypisać możemy grubość, rodzaj/styl linii (przerywana, ciągła, kropkowana…) i kolor. Przy nadawaniu wartości powinna być zachowana powyższa kolejność, czyli: grubość, styl, kolor:
 
 ```css
  border: 2px solid #f14b5c;
 ```
-Dostępne style linii to m.in : `solid` (ciągła), `dotted` (kropkowana), `dashed` (przerywana) czy `double` (podwójna).
+Dostępne style linii to m.in.: `solid` (ciągła), `dotted` (kropkowana), `dashed` (przerywana) czy `double` (podwójna).
 
 ```css
 p {
@@ -195,10 +195,10 @@ p {
   background-color: #FFE7EC; /* kolor jasnoróżowy */
 }
 ```
-<p style="color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b5c;">To jest paragraf o kolorze pomarańczowym na jasnoróżowym tle.</p>
+<p style="color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b5c;">To jest akapit o kolorze pomarańczowym na jasnoróżowym tle.</p>
 
 <!-- ### Dodawanie dopełnień (`padding`)
-Dopełnienie definiowane jest jako odległość między obramowaniem elementu a jego zawartością. Dla każdej strony mogą być to inne wartości. 
+Dopełnienie definiowane jest jako odległość między obramowaniem elementu a jego zawartością. Dla każdej strony mogą być to inne wartości.
 Np 'padding: 5px 10px 15px 20px', oznacza, że dopełnienie od góry wynosi 5px, od prawej 10px, od dołu 15px a od góry 20px. Żeby łatwiej było Ci wpisywać te wartości zapamiętaj, że są one definiowane zgodnie z kierunkiem wskazówek zegara (zaczynając od góry, prawo, dół, lewo).
 
 ```css
@@ -224,10 +224,11 @@ Wynik:<p style="color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b
 ### Wyrównanie tekstu (`text-align`)
 
 Tekst może zostać wyrównany na trzy różne sposoby:
-- do prawej `text-align: right;`
-- do lewej `text-align: left;`
-- do środka `text-align: center;`
-- wyjustowany `text-align: justify;`
+- do prawej (`text-align: right;`),
+- do lewej (`text-align: left;`),
+- do środka (`text-align: center;`).
+
+Dodatkowo tekst może być wyjustowany (`text-align: justify;`).
 
 ```css
 p {
@@ -237,13 +238,13 @@ p {
   background-color: #FFE7EC; /* kolor jasnoróżowy */
 }
 ```
-<p style="color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b5c; text-align: center;">To jest paragraf o kolorze pomarańczowym na jasnoróżowym tle.</p>
+<p style="color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b5c; text-align: center;">To jest akapit o kolorze pomarańczowym na jasnoróżowym tle.</p>
 
 ### Odmiana (grubość) pisma (`font-weight`)
 
-Ta właściwość okaże się przydatna zwłaszcza w kolejnym rozdziale, kiedy będziemy wybierać niestandardowe rodziny fontów. Wtedy zauważycie, że dany krój może mieć różne grubości. CSS umożliwia ostylowanie tekstu różnymi odmianami. 
-Wartości `font-weight` mogą być liczbami np. <i>100, 300, 500, 700</i> lub określone słownie np. <i>normal, bold, light, lighter</i>.
-Pamiętajmy tylko, że nie każdy, wybrany przez nas krój pisma posiadać będzie różne odmiany - w tych przypadkach właściwość CSS w żaden sposób nie wpłynie na zmianę grubości.
+Ta właściwość okaże się przydatna zwłaszcza w kolejnym rozdziale, kiedy będziemy wybierać niestandardowe rodziny fontów. Wtedy zauważycie, że dany krój może mieć różne grubości. CSS umożliwia ostylowanie tekstu różnymi odmianami danego fonta.
+Wartości `font-weight` mogą być liczbami, np. <i>100, 300, 500, 700</i>, lub określone słownie, np. <i>normal, bold, light, lighter</i>.
+Pamiętajmy tylko, że nie każdy wybrany przez nas krój pisma posiadać będzie różne odmiany – w tych przypadkach właściwość CSS w żaden sposób nie wpłynie na zmianę grubości.
 
 ```css
 p {
@@ -254,13 +255,13 @@ p {
   background-color: #FFE7EC; /* kolor jasnoróżowy */
 }
 ```
-<p style="font-weight: bold; color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b5c; text-align: center;">To jest paragraf o kolorze pomarańczowym na jasnoróżowym tle.</p>
+<p style="font-weight: bold; color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b5c; text-align: center;">To jest akapit o kolorze pomarańczowym na jasnoróżowym tle.</p>
 
-Czy zauważyliście, w porównaniu do paragrafu z zagadanienia wyżej, że font stał się grubszy?
+Czy zauważyliście, w porównaniu do akapitu z zagadanienia wyżej, że font stał się grubszy?
 
 ### Stopień (rozmiar) pisma (`font-size`)
 
-Możemy przypisywać tekstom różne rozmiary pisma. Istnieje kilka jednostek: `px` (piksele), `rem`, `em` czy nawet `%` procenty. Na razie skupmy się na pikselach, a znaczenie pozostałych jednostek wyjaśnimy już niebawem. 
+Możemy przypisywać tekstom różne rozmiary pisma. Istnieje kilka jednostek: `px` (piksele), `rem`, `em` czy nawet `%` (procenty). Na razie skupmy się na pikselach, a znaczenie pozostałych jednostek wyjaśnimy już niebawem.
 
 ```css
 p {
@@ -271,11 +272,11 @@ p {
   background-color: #FFE7EC; /* kolor jasnoróżowy */
 }
 ```
-<p style="font-size: 36px; color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b5c; text-align: center;">To jest paragraf o kolorze pomarańczowym na jasnoróżowym tle.</p>
+<p style="font-size: 36px; color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b5c; text-align: center;">To jest akapit o kolorze pomarańczowym na jasnoróżowym tle.</p>
 
 ### Styl fontu (`font-style`)
 
-Służy do tego właściwość: `font-style: italic;`, gdzie italic to nic innego jak kursywa. Lub `font-style: normal;`.
+Służy do tego właściwość: `font-style: italic;`, gdzie `italic` to nic innego jak kursywa. Normalny tekst uzyskamy, używając `font-style: normal;`.
 
 ```css
 p {
@@ -287,7 +288,7 @@ p {
   border: 2px solid #f14b5c;
 }
 ```
-<p style="font-style: italic; font-size: 20px; color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b5c; text-align: center;">To jest paragraf o kolorze pomarańczowym na jasnoróżowym tle.</p>
+<p style="font-style: italic; font-size: 20px; color: #f14b5c ;background-color:#FFE7EC;border: 1px solid #f14b5c; text-align: center;">To jest akapit o kolorze pomarańczowym na jasnoróżowym tle.</p>
 
 Pozostałe właściwości CSS poznamy już niedługo!
 
@@ -314,24 +315,26 @@ Pierwszym z nich jest dołączenie zewnętrznego pliku z rozszrzeniem `.css`, w 
 
 ```html
 <link href="tu wpisz ścieżkę do pliku css" rel="stylesheet">
-``` 
+```
+
 Znacznik `<link>` znajduje się w części `<head>` naszego dokumentu HTML.
+
 ```html
 <html lang="pl-PL">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Darmowe warsztaty z programowania HTML i CSS.">
-    <title>The Awwwesomes - Darmowe warsztaty z programowania HTML & CSS</title>
+    <title>The Awwwesomes – Darmowe warsztaty z programowania HTML & CSS</title>
     <!--poniżej załączony jest plik z arkuszami stylów, czyli plik CSS-->
-    <link rel="stylesheet" href="/styles/website.css"> 
+    <link rel="stylesheet" href="/styles/website.css">
   </head>
   <body>
 ```  
 
 > #### Important::Ważne
 >
-> Kolejność załączania plików CSS ma znaczenie. Może zdarzyć się sytuacja, że Waszym projekcie dołączać będziecie do strony więcej niż jeden plik CSS. Kiedy w obu z nich będą występować te same selektory, lecz zawierające różne właściwości, przeglądarka z pierwszeństwem potraktuje ten selektor, który został załączony jako ostatni. 
+> Kolejność załączania plików CSS ma znaczenie. Może zdarzyć się sytuacja, że Waszym projekcie dołączać będziecie do strony więcej niż jeden plik CSS. Kiedy w obu z nich będą występować te same selektory, lecz zawierające różne właściwości, przeglądarka z pierwszeństwem potraktuje ten selektor, który został załączony jako ostatni.
 > Zilustrujmy to przykładem. Do pliku `index.html` dołączone są następujące pliki css:
 >```html
 <link href="/styles/style-1.css" rel="stylesheet">
@@ -342,18 +345,18 @@ Znacznik `<link>` znajduje się w części `<head>` naszego dokumentu HTML.
 h1 {
   color: red;
 }
-``` 
+```
 >A w pliku `style-2.css`
 >```css
 h1 {
   color: green;
 }
-``` 
+```
 >to przeglądarka nada naszemu nagłówkowi kolor zielony, gdyż występuje on jako *ostatni*.
 
 ## Inne sposoby dołączania stylów
 
-Poznaliśmy już dodawanie stylów poprzez dołączanie zewnętrznego pliku - pliku CSS. Kolejną metodą jest napisanie CSS-owych deklaracji między znacznikami `<style> </style>` w sekcji `<head>`, jest to tzw. **arkusz osadzony** w dokumencie HTML.
+Poznaliśmy już dodawanie stylów poprzez dołączanie zewnętrznego pliku CSS. Kolejną metodą jest napisanie CSS-owych deklaracji między znacznikami `<style> </style>` w sekcji `<head>`. Jest to tzw. <b>arkusz osadzony</b> w dokumencie HTML.
 
 Przykładowo
 ```html
@@ -362,7 +365,7 @@ Przykładowo
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Darmowe warsztaty z programowania HTML i CSS.">
-    <title>The Awwwesomes - Darmowe warsztaty z programowania HTML & CSS</title>
+    <title>The Awwwesomes – Darmowe warsztaty z programowania HTML & CSS</title>
     <!--poniżej załączony jest plik z arkuszami stylów, czyli plik CSS-->
     <style>
         p {
@@ -373,27 +376,27 @@ Przykładowo
     </style>
   </head>
   <body>
-    <p>To jest paragraf o kolorze pomarańczowym na jasnoróżowym tle.</p>
+    <p>To jest akapit o kolorze pomarańczowym na jasnoróżowym tle.</p>
   </body>
 </html>
 ```
 
-Trzecia metoda - *inline*'owe dołączanie stylów, czyli **styl wpisany**. jest raczej rzadko stosowana. Style wpisujemy po prostu w danym tagu.
+Trzecia metoda – <i>inline'owe</i> dołączanie stylów, czyli <i>styl wpisany</i> – jest raczej rzadko stosowana. Style wpisujemy po prostu w danym tagu.
 
 ```html
- <p style="color: #f14b5c;">Ten paragraf jest ostylowany poprzez styl wpisany.</p>
+ <p style="color: #f14b5c;">Ten akapit jest ostylowany poprzez styl wpisany.</p>
  ```
 
 Każdą kolejną właściwość dodajemy po średniku:
 
 ```html
-<p style="color: #f14b5c; background-color: #FFE7EC;">Ten paragraf jest ostylowany poprzez styl wpisany.</p>
+<p style="color: #f14b5c; background-color: #FFE7EC;">Ten akapit jest ostylowany poprzez styl wpisany.</p>
 ```
 
 > #### Important::Ważne
 >
-> Dlaczego styl wpisany, czyli połączenie tagu i właściowści CSS-owych jest rzadko stosowane? 
-Odseparowanie HTML-a oraz CSS-a zdecydowanie ułatwia życie np. przy późniejszych modyfikacjach kodu i uznane jest za bardziej elegancką metodę. Dlatego też starajmy się pisać style w oddzielnym pliku.
+> Dlaczego styl wpisany, czyli połączenie tagu i właściowści CSS-owych, jest rzadko stosowane?
+Odseparowanie HTML-a od CSS-a zdecydowanie ułatwia życie np. przy późniejszych modyfikacjach kodu i uznane jest za bardziej elegancką metodę. Dlatego też starajmy się pisać style w oddzielnym pliku.
 
 Zobaczyliśmy, jak wyglądają proste selektory i właściwości CSS, zatem pora na pierwsze ćwiczenie!
 
@@ -401,19 +404,19 @@ Zobaczyliśmy, jak wyglądają proste selektory i właściwości CSS, zatem pora
 >
 > W tym ćwiczeniu nauczysz się jak poprawnie załączać plik CSS do Twojej strony.
 >
-> - Otwórz folder z projektem `planty`, zawierający podstawowy kod z poprzednich zajęć (patrz [Ćwiczenie 6](../html-document-structure/README.md). 
-> - Stwórz pusty plik `style.css` i zapisz go do nowo utworzonego folderu `/styles`. 
-> - Podepnij nowo utworzony plik CSS do `index.html`. W tym celu zastosuj znacznik `<link href="ścieżka do Twojego pliku css" rel="stylesheet">` z odpowiednio uzupełnionymi atrybutami. Przy okazji przećwiczysz ścieżki względne. 
+> - Otwórz folder z projektem `planty`, zawierający podstawowy kod z poprzednich zajęć (patrz [Ćwiczenie 6](../html-document-structure/README.md).
+> - Stwórz pusty plik `style.css` i zapisz go do nowo utworzonego folderu `/styles`.
+> - Podepnij nowo utworzony plik CSS do `index.html`. W tym celu zastosuj znacznik `<link href="ścieżka do Twojego pliku css" rel="stylesheet">` z odpowiednio uzupełnionymi atrybutami. Przy okazji przećwiczysz ścieżki względne.
 
->**Ważne** - znacznik `<link>` dodawany jest pomiędzy znacznikami `<head>` i `</head>`, najlepiej po znacznikach `<meta>`. 
+>**Ważne!** Znacznik `<link>` dodawany jest pomiędzy znacznikami `<head>` i `</head>`, najlepiej po znacznikach `<meta>`.
 
-Jak sprawdzić czy plik CSS został poprawnie dołączony do strony? Najlepiej poprzez zweryfikowanie czy zdefiniowane przez nas style prawidłowo się wyświetlają. Plik `style.css` jest pusty. Pora zatem na napisanie pierwszych CSS-owych deklaracji!
+Jak sprawdzić, czy plik CSS został poprawnie dołączony do strony? Najlepiej poprzez zweryfikowanie, czy zdefiniowane przez nas style prawidłowo się wyświetlają. Plik `style.css` jest pusty. Pora zatem na napisanie pierwszych CSS-owych deklaracji!
 
 > #### Exercise::Ćwiczenie 8
 >
 > W tym ćwiczeniu postawisz swoje pierwsze CSS-owe kroki. Nareszcie Twój kod HTML nabierze życia i zmieni kolory! Gotowy?
-> - Zacznijmy od stworzenia nowego folderu z `exercise-8` i pliku `index.html` zawartego w tym katalogu. 
-> - Stwórz szkielet strony na podstawie poniższego widoku, a następnie ostyluj go. 
+> - Zacznijmy od stworzenia nowego folderu z `exercise-8` i pliku `index.html` zawartego w tym katalogu.
+> - Stwórz szkielet strony na podstawie poniższego widoku, a następnie ostyluj go.
 
 ><div class="example-wrapper" style="background: #ffcbd7; ">
   <article>
@@ -440,8 +443,3 @@ Jak sprawdzić czy plik CSS został poprawnie dołączony do strony? Najlepiej p
     <button type="submit" style="background: #282f5f; color:#fff !important; border: 0; font-size: 20px; ">Prześlij</button>
   </form>
 </div>
-
-
-
-
-

--- a/pl/css-code/README.md
+++ b/pl/css-code/README.md
@@ -95,6 +95,10 @@ Nadajmy tekstowi w naszej kontrolce kolor czerwony, odnosząc się do niego po `
 
 Przypomnijmy, że w jednym dokumencie wartości atrybutu `id` powinny być unikalne. W związku z tym style zawarte wewnątrz tego selektora nie są zbyt reużywalne – możemy je zastosować tylko dla jednego, konkretnego elementu na stronie.
 
+> #### Important::Ważne
+>
+> Choć stylowanie po atrybucie `id` jest możliwe, od dawna jest uważane za [złą praktykę](http://forum.pasja-informatyki.pl/109776/html-class-czy-id?show=109816#a109816).
+
 ### Atrybut
 
 Stylować można również elementy zawierające konkretny atrybut. Dobrym przykładem jest np. tag `<input type="text">`. W tym wypadku deklaracja CSS będzie dotyczyła kontrolek `input` typu text.

--- a/pl/css-fonts/README.md
+++ b/pl/css-fonts/README.md
@@ -1,17 +1,18 @@
 # Dołączanie fontów Google Fonts
 
-Pora na chwilę oddechu - nauczymy się wreszcie dołączać inne kroje pisma.
+Pora na chwilę oddechu – nauczymy się wreszcie dołączać inne kroje pisma.
 
-Kolory i typografia niewątpliwie wpływają na charakter strony i to jak ją odbieramy. Całe szczęście dołączanie różnych, niestandardowych krojów pisma stało się możliwe i całkiem proste, o czym zaraz się przekonacie.
+Kolory i typografia niewątpliwie wpływają na charakter strony i to jak ją odbieramy. Na całe szczęście dołączanie różnych, niestandardowych krojów pisma stało się możliwe i całkiem proste, o czym zaraz się przekonacie.
 
 Zanim jednak zaczniemy szukać odpowiedniego kroju, musimy pamiętać, że jedynie fonty zapisane w odpowiednich formatach będą renderowane w konkretnych przeglądarkach internetowych.  Pamiętajmy, że posiadanie danego fontu na komputerze i jego poprawne wyświetlanie na naszym systemie, nie oznacza, że będzie się on poprawnie wyświetlać u wszystkich innych użytkowników. Cała magia tkwi w tym, by font został wyrenderowany, pomimo faktu, iż użytkownicy nie mają danego kroju pisma zainstalowanego na swoich komputerach. W tym celu najlepiej korzystać z <a href="https://www.google.com/fonts">Google Fonts</a> lub fontów webowych, których pliki należy zaimportować do CSS-a. Tę drugą metodę poznamy nieco później.
 
 Obecnie istnieje wiele portali, które darmowo udostępniają bardzo wiele różnych fontów. Jednym z najczęściej używanych jest <a href="https://www.google.com/fonts">Google Fonts</a>.
 
 ## Jak podłączyć font z Google Fonts?
-Odwiedźmy stronę <a href="https://www.google.com/fonts">Google Fonts</a> i wybierzmy font. W naszym layoucie Planty wykorzystane zostały trzy różne rodziny fontów: <i>Playfair Display</i>, <i>Montserat</i> oraz <i>Muli</i>. Znajdziemy je na <a href="https://www.google.com/fonts">Google Fonts</a>. 
+Odwiedźmy stronę <a href="https://www.google.com/fonts">Google Fonts</a> i wybierzmy font. W naszym layoucie Planty wykorzystane zostały trzy różne rodziny fontów: <i>Playfair Display</i>, <i>Montserat</i> oraz <i>Muli</i>. Znajdziemy je na <a href="https://www.google.com/fonts">Google Fonts</a>.
 Fonty te poza tym, że mogą zostać podpięte pod naszą stronę, mogą także zostać ściągnięte i zainstalowane na naszych komputerach.
-Jeśli <i>Playfair Display</i> został już znaleziony, należy kliknąć w ikonę <i>Quick use</i> zaznaczoną pomarańczowym kółkiem.
+
+Jeśli szukany przez nas font (np. <i>Playfair Display</i>) został już znaleziony, należy kliknąć w ikonę <i>Quick use</i> zaznaczoną pomarańczowym kółkiem.
 
 > ![](/images/googlefonts-quickuse.png "")
 
@@ -19,25 +20,25 @@ W punkcie 1. wybierzmy interesujące nas style danego kroju. W projekcie Planty 
 
 > ![Layout do zakodowania](/images/googlefonts-styles.png "Layout do zakodowania")
 
-Jeśli tworzymy stronę w języku polskim upewnijmy się czy font wyposażony jest w polskie znaki. Można to sprawdzić wpisując tekst w Google Fonts i obserwując jak te znaki są wyświetlane. Domyślnie font nie ma zaznaczonego checkboksa "Latin extended", który zawiera m.in. polskie znaki. 
+Jeśli tworzymy stronę w języku polskim, upewnijmy się czy font wyposażony jest w polskie znaki. Można to sprawdzić wpisując tekst w Google Fonts i obserwując jak te znaki są wyświetlane. Domyślnie font nie ma zaznaczonego checkboksa "Latin extended", który zawiera m.in. polskie znaki.
 
 
-Pamiętajmy, żeby zaznaczyć tę opcję, jeśli ich potrzebujemy. W przypadku Planty możemy zostawić opcję domyślną (teksty są w języku angielskim).
+Pamiętajmy, żeby zaznaczyć tę opcję, jeśli potrzebujemy polskich znaków. W przypadku Planty możemy zostawić opcję domyślną (teksty są w języku angielskim).
 
 
-Zgodnie z tym, co znajdziesz w punkcie 3 - należy umieścić poniższy tag w sekcji` <head>`.
+Zgodnie z tym, co znajdziesz w punkcie 3, należy umieścić poniższy tag w sekcji` <head>`.
 ```html
 <link href='https://fonts.googleapis.com/css?family=Playfair+Display:400,400italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
 ```
-Dzięki znacznikowi link, podłączyliśmy do naszej strony font "Playfair Display", ale na samej stronie nic się nie zmieniło - ciągle wyświetlany jest domyślny font systemowy. Pozostało jeszcze podpięcie wybranego fonty do arkusza stylów. Dzieję się to dzięki właściwości `font-family`. W punkcie 4. na stronie Google Fonts znajdziemy nazwę fontu, którą trzeba zastosować. 
+Dzięki znacznikowi `<link>`, podłączyliśmy do naszej strony font "Playfair Display", ale na samej stronie nic się nie zmieniło – ciągle wyświetlany jest domyślny font systemowy. Pozostało jeszcze podpięcie wybranego fonta do arkusza stylów. Dzieje się to dzięki właściwości `font-family`. W punkcie 4. na stronie Google Fonts znajdziemy nazwę fontu, którą trzeba zastosować.
 
 ```css
 ul li {
 	font-family: 'Playfair Display', serif;
 }
 ```
-Zastanówmy się jeszcze co oznacza wartość `'Playfair Display', serif;` i dlaczego występuje tam nazwa `serif`. 
-Otóż jeśli nie zostanie znaleziony font o nazwie `'Playfair Display'` (np. nie dołączymy do naszego kodu skryptu ze strony Google Fonts), to przeglądarka wyświetli dowolny, dostępny font szeryfowy właśnie dzięki wartości `serif`. 
+Zastanówmy się jeszcze, co oznacza wartość `'Playfair Display', serif;` i dlaczego występuje tam nazwa `serif`?
+Otóż jeśli nie zostanie znaleziony font o nazwie `'Playfair Display'` (np. nie dołączymy do naszego kodu skryptu ze strony Google Fonts), to przeglądarka wyświetli dowolny, dostępny font szeryfowy właśnie dzięki wartości `serif`.
 Deklarację możemy też rozbudować o większą liczbę krojów, np.
 
 ```css
@@ -45,17 +46,18 @@ ul li {
 	font-family: 'Playfair Display', 'Georgia', serif;
 }
 ```
-Co oznacza - wyświetl font 'Playfair Display', jeśli nie jest to możliwe, to wyświetl font 'Georgia', jeśli 'Georgia' nie została znaleziona to wyświetl dowolny font szeryfowy.
+
+Kod ten oznacza: "wyświetl font 'Playfair Display'; jeśli nie jest to możliwe, to wyświetl font 'Georgia'; jeśli 'Georgia' nie została znaleziona, to wyświetl dowolny font szeryfowy".
 
 
 Teraz możemy sprawdzić czy nasza lista na stronie Planty zmieniła font. W celu weryfikacji dla elementu listy odznaczmy właściwość `font-family` w Narzędziach Developerskich. Czy zaobserwowaliście zmianę fontu?
 
 > #### Exercise::Ćwiczenie 9
 >
-> Pora na podłączenie pozostałych dwóch fontów do Planty - są to <i>Muli (Normal 400)</i> oraz <i>Montserrat (Bold 700)</i>. Po podłączeniu fontów, przejdź do pliku CSS i przypisz paragrafom font <i>Muli</i>, natomiast tekstowi "because we care for plants" font <i>Montserrat</i>, tak żeby osiągnąc poniższy efekt: 
+> Pora na podłączenie pozostałych dwóch fontów do Planty. Są to <i>Muli (Normal 400)</i> oraz <i>Montserrat (Bold 700)</i>. Po podłączeniu fontów, przejdź do pliku CSS i przypisz akapitom font <i>Muli</i>, natomiast tekstowi "because we care for plants" font <i>Montserrat</i>, tak żeby osiągnąc poniższy efekt:
 
 > ![Podłączone fonty: Muli, Montserrat oraz Playfair Display](/images/googlefonts-layout.png "Podłączone fonty: Muli, Montserrat oraz Playfair Display")
 >Renderowanie fontów może nieco różnić się w zależności od przeglądarki, więc nie przejmuj się na razie, jeśli u Ciebie fonty wyglądają na "cieńsze" lub "bardziej tłuste". Pomińmy też na tym etapie wielkości fontów.
 >
 
-Możesz dodawać dowolną ilość niesystemowych fontów. Pamiętaj jednak, że fonty ładowane są wraz z ładowaniem strony internetowej. Przy wolniejszym transferze internetowym zauważyć można doładowywanie fontów.
+Możesz dodawać dowolną liczbę niesystemowych fontów. Pamiętaj jednak, że fonty ładowane są wraz z ładowaniem strony internetowej. Przy wolniejszym transferze internetowym zauważyć można doładowywanie fontów.

--- a/pl/css-layout/README.md
+++ b/pl/css-layout/README.md
@@ -1,3 +1,3 @@
 # Tworzenie layoutu strony
 
-Po przeczytaniu poprzednich rozdziałów zapewne głowy pękają Wam od teorii. Jeśli udało się Wam przez to wszystko przebrnąć - jesteśmy z Was bardzo dumni! I zapraszamy w podróż do świata layoutu stron internetowych. Tutaj również można zagubić się w gąszczu różnych zagadnień, jednak każde z nich jest bardzo ważne i potrzebne w codziennej pracy frontendowca. Gotowi?
+Po przeczytaniu poprzednich rozdziałów zapewne głowy pękają Wam od teorii. Jeśli udało się Wam przez to wszystko przebrnąć – jesteśmy z Was bardzo dumni! I zapraszamy w podróż do świata layoutu stron internetowych. Tutaj również można zagubić się w gąszczu różnych zagadnień, jednak każde z nich jest bardzo ważne i potrzebne w codziennej pracy front-endowca. Gotowi?

--- a/pl/css-layout/css-block-inline-elements.md
+++ b/pl/css-layout/css-block-inline-elements.md
@@ -1,10 +1,10 @@
 ## Elementy liniowe i blokowe oraz właściwość `display`
 
-W poprzednich rozdziałach poznaliście dwa generyczne tagi HTML: `<div>` oraz `<span>`. Zapewne udało się Wam już użyć ich w swoim kodzie. Skąd wzięła się potrzeba wprowadzania aż dwóch rodzajów domyślnych znaczników? Zostało to już krótko wspomniane - `<div>` odnosi się do elementów, które mają być wyświetlane jako **blokowe**, natomiast `<span>` zwykle jest używany dla elementów **liniowych**.
+W poprzednich rozdziałach poznaliście dwa generyczne tagi HTML: `<div>` oraz `<span>`. Zapewne udało się Wam już użyć ich w swoim kodzie. Skąd wzięła się potrzeba wprowadzania aż dwóch rodzajów domyślnych znaczników? Zostało to już krótko wspomniane: `<div>` odnosi się do elementów, które mają być wyświetlane jako <b>blokowe</b>, natomiast `<span>` zwykle jest używany dla elementów <b>liniowych</b>.
 
 ### Elementy blokowe
 
-Elementy blokowe to elementy, które mają  być wyświetlane jako **bloki**. 
+Elementy blokowe to elementy, które mają  być wyświetlane jako <b>bloki</b>.
 
 - Jeśli nie określimy jego szerokości wprost, każdy blok domyślnie będzie zajmował 100% szerokości swojego rodzica.
 - Możemy określić jego marginesy oraz wypełnienie (padding).
@@ -36,7 +36,7 @@ Elementy blokowe to elementy, które mają  być wyświetlane jako **bloki**.
   </div>
 </div>
 
-Przykładami elementów HTML, które przez przeglądarkę są domyślnie wyświetlane jako blokowe to wspomniany już `<div>`, `<p>`, `<header>`, `<section>`, `<nav>`, `<footer>`, `<article>`, `<form>`, `<ul>`, `<ol>` oraz nagłówki, np. `<h1>`.
+Przykładami elementów HTML, które przez przeglądarkę są domyślnie wyświetlane jako blokowe, to wspomniany już `<div>`, ale też `<p>`, `<header>`, `<section>`, `<nav>`, `<footer>`, `<article>`, `<form>`, `<ul>`, `<ol>` oraz nagłówki, np. `<h1>`.
 
 ### Elementy liniowe
 
@@ -44,13 +44,13 @@ Elementy liniowe to takie, które zachowują się jak linie tekstu, czyli innymi
 
 - Nie można określić im wymiarów za pomocą właściwości `width` i `height`.
 - Nie można nadwać im górnych (`margin-top`), ani dolnych (`margin-bottom`) marginesów. Nadanie `margin-left` lub `margin-right` oraz wypełnień jednak w ich przypadku zadziała.
-- Biorąc pod uwagę, że elementy liniowe zachowują się podobnie, jak linie tekstu, można określać ich wyrównanie w pionie za pomocą właściwości `vertical-align`. Zachowanie [`vertical-align`](https://developer.mozilla.org/en/docs/Web/CSS/vertical-align) zostało bardzo przejrzyście wytłumaczone w [tym artykule](https://bitsofco.de/the-vertical-align-property/).
+- Biorąc pod uwagę, że elementy liniowe zachowują się podobnie, jak linie tekstu, można określać ich wyrównanie w pionie za pomocą właściwości `vertical-align`. Zachowanie [`vertical-align`](https://developer.mozilla.org/en/docs/Web/CSS/vertical-align) zostało bardzo przejrzyście wytłumaczone w [artykule na BitsOfCo.de](https://bitsofco.de/the-vertical-align-property/).
 
 ```html
 <p>
-  Hipster cornhole celiac kickstarter asymmetrical cred meggings. 
-  Retro pitchfork semiotics you 
-  <span class="inline">probably haven't heard of them</span>, 
+  Hipster cornhole celiac kickstarter asymmetrical cred meggings.
+  Retro pitchfork semiotics you
+  <span class="inline">probably haven't heard of them</span>,
   thundercats occupy raw denim DIY.
 </p>
 ```
@@ -69,19 +69,19 @@ Elementy liniowe to takie, które zachowują się jak linie tekstu, czyli innymi
 
 Przykładowe elementy liniowe, które już udało nam się poznać to `<span>` oraz `<a>`.
 
-Warto w tym momencie wspomnieć, że istnieją elementy, których domyślne zachowanie nieco różni się od blokowych i liniowych - można powiedzieć, że łączą w sobie rózne ich cechy. Są to tzw. [*replaced elements*](http://www.impressivewebs.com/difference-block-inline-css/). Należą do nich m.in. `<img>`, `<input>` oraz `<select>`. Można określać ich wymiary za pomocą właściwości CSS, jednak w przeciwieństwie do elementów blokowych za żadnym z nich nie następuje złamanie linii. Zauważyliście to z pewnością podczas tworzenia formularzy w czystym HTML.
+Warto w tym momencie wspomnieć, że istnieją elementy, których domyślne zachowanie nieco różni się od blokowych i liniowych. Można powiedzieć, że łączą w sobie ich wybrane cechy. Są to tzw. [<i>replaced elements</i>](http://www.impressivewebs.com/difference-block-inline-css/). Należą do nich m.in. `<img>`, `<input>` oraz `<select>`. Można określać ich wymiary za pomocą właściwości CSS, jednak w przeciwieństwie do elementów blokowych za żadnym z nich nie następuje złamanie linii. Zauważyliście to z pewnością podczas tworzenia formularzy w czystym HTML.
 
 ### Określamy zachowanie elementów za pomocą właściwości `display`
 
 Każdy z elementów HTML posiada swój domyślny rodzaj zachowania, jednak można w bardzo łatwy sposób go zmienić i sprawić, żeby np. `<div>` zaczął zachowywać się jak element liniowy.
 
-Jak to zrobić? Poznajmy właściwość `display`, która odpowiada za określanie rodzaju sposobu wyświetlania elementu na stronie. Wartości właściwości display jest [bardzo dużo](https://developer.mozilla.org/en-US/docs/Web/CSS/display) i sporo z nich brzmi tajemniczo nawet dla całkiem zaawansowanych deweloperów CSS.
+Jak to zrobić? Poznajmy właściwość `display`, która odpowiada za określanie rodzaju sposobu wyświetlania elementu na stronie. Wartości właściwości `display` jest [bardzo dużo](https://developer.mozilla.org/en-US/docs/Web/CSS/display) i sporo z nich brzmi tajemniczo nawet dla całkiem zaawansowanych deweloperów CSS.
 
 Poznajmy trzy używane zdecydowanie najczęściej:
 
-- `display: inline` - sprawia, że element będzie wyświetlany jako element liniowy
-- `display: block` - element zostanie wyświetlony jako element blokowy
-- `display: inline-block` - łączy cechy elementów liniowych i blokowych, za jego pomocą możemy sprawić, że będzie możliwe nadanie naszemu elementowi wymiarów i wszystkich marginesów, a także nie nastąpi po nim przejście do kolejnej linii.
+- `display: inline` – sprawia, że element będzie wyświetlany jako element liniowy.
+- `display: block` – element zostanie wyświetlony jako element blokowy.
+- `display: inline-block` – łączy cechy elementów liniowych i blokowych. Za jego pomocą możemy sprawić, że będzie możliwe nadanie naszemu elementowi wymiarów i wszystkich marginesów, a także nie nastąpi po nim przejście do kolejnej linii.
 
 ```html
 <div class="container">

--- a/pl/css-layout/css-centering.md
+++ b/pl/css-layout/css-centering.md
@@ -1,6 +1,6 @@
 ## Jak wyśrodkować elementy w pionie i poziomie?
 
-Częstym problemem w kodowaniu layoutu strony jest środkowanie elementów. Poinstruowanie przeglądarki, aby umieściła nasz wybrany element wydaje się dość skomplikowanym zadaniem.
+Częstym problemem w kodowaniu layoutu strony jest środkowanie elementów. Poinstruowanie przeglądarki, aby umieściła nasz wybrany element w konkretnym miejscu, wydaje się dość skomplikowanym zadaniem.
 
 W tym rodziale postaramy się pokazać Wam, że nie jest to wcale takie trudne i wystarczy poznać kilka prostych technik, aby stać się mistrzem środkowania w CSS.
 
@@ -44,8 +44,8 @@ To, jakiej techniki środkowania w poziomie użyć zależy w dużej mierze od te
 ```
 
 ```css
-/* 
-  Ważne, aby wyśrodkowanie 
+/*
+  Ważne, aby wyśrodkowanie
   zdefiniować na elemencie otaczającym
 */
 .container {
@@ -68,7 +68,7 @@ To, jakiej techniki środkowania w poziomie użyć zależy w dużej mierze od te
 
 ### Środkowanie w pionie
 
-Środkowanie elementów w pionie jest nieco bardziej skomplikowane, niż środkowanie w poziomie. Techniki środkowania w pionie dla elementów liniowych wymagają już nieco wprawy i zaawansowania w CSS, to samo dotyczy elementów blokowych, których wymiary nie są określone wprost. Wszystkich ambitnych, którzy chcą zapoznać się z tajnikami środkowania, odsyłamy do [tego artykułu](https://css-tricks.com/centering-css-complete-guide/).
+Środkowanie elementów w pionie jest nieco bardziej skomplikowane, niż środkowanie w poziomie. Techniki środkowania w pionie dla elementów liniowych wymagają już nieco wprawy i zaawansowania w CSS, to samo dotyczy elementów blokowych, których wymiary nie są określone wprost. Wszystkich ambitnych, którzy chcą zapoznać się z tajnikami środkowania, odsyłamy do [artykułu na CSS Tricks](https://css-tricks.com/centering-css-complete-guide/).
 
 Dowiedzmy się zatem, w jaki sposób wyśrodkować element blokowy o znanej wysokości.
 

--- a/pl/css-layout/css-floats.md
+++ b/pl/css-layout/css-floats.md
@@ -126,7 +126,7 @@ Powyższy przykład demonstruje klasyczny przypadek użycia `float` i odnosi si�
   </div>
 </div>
 >
-> Niestety, nie jest to wcale idealne rozwiązanie. Nie chcemy w końcu zaśmiecać naszej strony pustymi elementami użytymi tylko ze względu na wygląd. Istnieje nieco lepszy sposób oparty na <i>pseudoelementach</i> (co to takiego, dowiemy się już niebawem) – tzw. [*micro-clearfix*](http://nicolasgallagher.com/micro-clearfix-hack/).
+> Niestety, nie jest to wcale idealne rozwiązanie. Nie chcemy w końcu zaśmiecać naszej strony pustymi elementami użytymi tylko ze względu na wygląd. Istnieją nieco lepsze sposób, oparte na <i>pseudoelementach</i> (co to takiego, dowiemy się już niebawem) – tzw. [*micro-clearfix*](http://nicolasgallagher.com/micro-clearfix-hack/) – oraz [własności `overflow`](http://www.forumweb.pl/porady-i-tutoriale-www/css-clearowanie-czyli-problemy-z-float,47914).
 
 Opływanie w CSS często przydaje się do tworzenia całych layoutów oraz poszczególnych komponentów strony.
 

--- a/pl/css-layout/css-floats.md
+++ b/pl/css-layout/css-floats.md
@@ -1,11 +1,11 @@
 ## Opływanie elementów
 
-Kolejną właściwością, która pomaga nam w budowaniu layoutów jest `float`, który definiuje **opływanie** elementów.
+Kolejną właściwością, która pomaga nam w budowaniu layoutów, jest `float`, który definiuje <b>opływanie</b> elementów.
 
 ```html
 <p>
   <img src="latte.jpg" alt="cup of latte" class="latte">
-  Cred paleo whatever, portland distillery microdosing pabst. Salvia seitan cardigan kinfolk yuccie, chia umami viral blog. Waistcoat tilde next level, tote bag stumptown four loko franzen. Small batch vice swag, offal chia kickstarter helvetica pitchfork. 
+  Cred paleo whatever, portland distillery microdosing pabst. Salvia seitan cardigan kinfolk yuccie, chia umami viral blog. Waistcoat tilde next level, tote bag stumptown four loko franzen. Small batch vice swag, offal chia kickstarter helvetica pitchfork.
   <img src="bicycle.jpg" alt="hipster bicycle" class="bicycle">
   Cornhole schlitz master cleanse, fap flannel plaid you probably haven't heard of them flexitarian tousled echo park fanny pack viral. Bushwick paleo pour-over, schlitz cred 3 wolf moon try-hard flexitarian chartreuse sustainable vegan beard. Asymmetrical pabst tumblr neutra helvetica.
 </p>
@@ -24,7 +24,7 @@ Kolejną właściwością, która pomaga nam w budowaniu layoutów jest `float`,
 <div class="example-wrapper">
   <p>
     <img src="../images/float-latte.jpg" alt="cup of latte" style="float:left">
-    Cred paleo whatever, portland distillery microdosing pabst. Salvia seitan cardigan kinfolk yuccie, chia umami viral blog. Waistcoat tilde next level, tote bag stumptown four loko franzen. Small batch vice swag, offal chia kickstarter helvetica pitchfork. 
+    Cred paleo whatever, portland distillery microdosing pabst. Salvia seitan cardigan kinfolk yuccie, chia umami viral blog. Waistcoat tilde next level, tote bag stumptown four loko franzen. Small batch vice swag, offal chia kickstarter helvetica pitchfork.
     <img src="../images/float-bicycle.jpg" alt="hipster bicycle" style="float:right">
     Cornhole schlitz master cleanse, fap flannel plaid you probably haven't heard of them flexitarian tousled echo park fanny pack viral. Bushwick paleo pour-over, schlitz cred 3 wolf moon try-hard flexitarian chartreuse sustainable vegan beard. Asymmetrical pabst tumblr neutra helvetica.
   </p>
@@ -45,7 +45,7 @@ Powyższy przykład demonstruje klasyczny przypadek użycia `float` i odnosi si�
 ```
 > ```css
 .item {
-  background: lightgreen; 
+  background: lightgreen;
   width: 100px;
   height: 100px;
   margin: 5px;
@@ -64,7 +64,7 @@ Powyższy przykład demonstruje klasyczny przypadek użycia `float` i odnosi si�
   <div style="float:left;width:100px;height:100px;margin:5px;background:lightblue;clear:both"></div>
 </div>
 >
-> Nasz ostatni element otrzymał właściwość `clear: both`, co oznacza, że zamiast opływać sąsiadujące elementy - i zostać umieszczony w tym samym rzędzie, co zielone kwadraty - pojawił się w następnej linii.
+> Nasz ostatni element otrzymał właściwość `clear: both`, co oznacza, że zamiast opływać sąsiadujące elementy – i zostać umieszczony w tym samym rzędzie, co zielone kwadraty – pojawił się w następnej linii.
 >
 > Spójrzmy jeszcze na przykład, gdzie wewnątrz kontenera znajdują się elementy z `float`.
 >
@@ -82,7 +82,7 @@ Powyższy przykład demonstruje klasyczny przypadek użycia `float` i odnosi si�
   padding: 3px;
 }
 .item {
-  background: lightgreen; 
+  background: lightgreen;
   width: 100px;
   height: 100px;
   margin: 5px;
@@ -126,7 +126,7 @@ Powyższy przykład demonstruje klasyczny przypadek użycia `float` i odnosi si�
   </div>
 </div>
 >
-> Niestety, nie jest to wcale idealne rozwiązanie. Nie chcemy w końcu zaśmiecać naszej strony pustymi elementami użytymi tylko ze względu na wygląd. Istnieje nieco lepszy sposób oparty na *pseudo-elementach* (co to takiego, dowiemy się już niebawem) - tzw. [*micro-clearfix*](http://nicolasgallagher.com/micro-clearfix-hack/).
+> Niestety, nie jest to wcale idealne rozwiązanie. Nie chcemy w końcu zaśmiecać naszej strony pustymi elementami użytymi tylko ze względu na wygląd. Istnieje nieco lepszy sposób oparty na <i>pseudoelementach</i> (co to takiego, dowiemy się już niebawem) – tzw. [*micro-clearfix*](http://nicolasgallagher.com/micro-clearfix-hack/).
 
 Opływanie w CSS często przydaje się do tworzenia całych layoutów oraz poszczególnych komponentów strony.
 

--- a/pl/css-layout/css-grid.md
+++ b/pl/css-layout/css-grid.md
@@ -1,25 +1,25 @@
 ## Umieszczamy elementy na siatce
 
-Każdy z Was, kto miał jak dotąd do czynienia z projektowaniem graficznym stron internetowych, z pewnością wie, do czego służy siatka. Jest ona bardzo ważna dla kompozycji strony, ułatwia harmonijne i estetyczne rozmieszczenie jej elementów. Spójrzmy, jak wygląda siatka naszego layoutu Planty:
+Każdy z Was, kto miał już do czynienia z projektowaniem graficznym stron internetowych, z pewnością wie, do czego służy siatka. Jest ona bardzo ważna dla kompozycji strony, ułatwia harmonijne i estetyczne rozmieszczenie jej elementów. Spójrzmy, jak wygląda siatka naszego layoutu Planty:
 
 ![Siatka projektu layoutu Planty][1]
 
 [1]: /images/planty-grid.jpg
 
-Zauważmy, że wszystkie elementy znajdują się w głównym kontenerze o szerokości **960 pikseli**, a sama siatka składa się z **12 kolumn**. Czy jest jakiś sposób, dzięki któremu możemy sprawić, aby można było łatwo rozmieszczać elementy bazując na siatce projektu? 
+Zauważmy, że wszystkie elementy znajdują się w głównym kontenerze o szerokości <b>960 pikseli</b>, a sama siatka składa się z <b>12 kolumn</b>. Czy jest jakiś sposób, dzięki któremu możemy sprawić, aby można było łatwo rozmieszczać elementy bazując na siatce projektu?
 
 W zasadzie podczas kodowania każdego projektu strony będziemy musieli skorzystać z gotowej siatki. Na szczęście również w tym wypadku można znaleźć sporo już istniejących rozwiązań i dołączyć wybrane do projektu.
 
-Dla ustalenia uwagi, zaprezentujemy Wam możliwości korzystania z siatki na przykładzie [Bootstrapa](http://getbootstrap.com/css/#grid). Bootstrap jest to tzw. *framework*, czyli gotowy zestaw narzędzi (m.in. klas CSS) pomocnych w rozwiązywaniu powtarzających się, standardowych problemów *webdesignu*, na przykład responsywnego menu lub właśnie siatki.
+W tym tutorialu zaprezentujemy Wam możliwości korzystania z siatki na przykładzie [Bootstrapa](http://getbootstrap.com/css/#grid). Bootstrap jest tzw. <i>frameworkiem</i>, czyli gotowym zestawem narzędzi (m.in. klas CSS) pomocnych w rozwiązywaniu powtarzających się, standardowych problemów <i>webdesignu</i>, na przykład responsywnego menu lub właśnie siatki.
 
 ### Budowanie kolumn w oparciu o siatkę z Boostrapa
 
-Do zbudowania layoutu w oparciu siatkę bootstrapową potrzebny nam plik CSS, w którym siatka jest opisana poprzez style. Kontener zawierający kolumny zdefiniowany jest dla kilku szerokości ekranu - dla desktopu, tabletu i smartfona, natomiast jej poszczególne składniki, czyli kolumny procentowo dostowują się do szerokości kontenera). Dzięki temu nasza strona odpowiednio wyświetla się na różnych urządzeniach. Niestety na naszym kursie nie starczy nam czasu, aby omówić zagadnienia związane z **projektowaniem responsywnym** (ang. <i>responsive o web design</i>), alę dzięki zastosowaniu responsywnej siatki będziemy mogli zaobserwować przynamniej jego częściowe efekty.
+Do zbudowania layoutu w oparciu o siatkę bootstrapową potrzebny nam plik CSS, w którym siatka jest opisana poprzez style. Kontener zawierający kolumny zdefiniowany jest dla kilku szerokości ekranu: dla desktopu, tabletu i smartfona. Jej poszczególne składniki, czyli kolumny, procentowo dostowują się do szerokości kontenera. Dzięki temu nasza strona odpowiednio wyświetla się na różnych urządzeniach. Niestety, w naszym kursie nie starczy nam czasu, aby omówić zagadnienia związane z <b>projektowaniem responsywnym</b> (ang. <i>responsive web design</i>), alę dzięki zastosowaniu responsywnej siatki będziemy mogli zaobserwować przynamniej jego częściowe efekty.
 
 Maksymalna liczba kolumn zawartych w danym kontenerze to 12. Żeby nasz element został spozycjonowany według siatki, musi się on zajmować między znacznikami takimi jak:
 `<div class="container">`, czyli kontener,
 `<div class="row">`, czyli rząd, w którym będą wyświetlać się nasze elementy
-oraz `<div class="col-md-12">`, czyli div zbudowany z zadanej ilości kolumn (w tym wypadku *12*)
+oraz `<div class="col-md-12">`, czyli `<div>` zbudowany z zadanej ilości kolumn (w tym wypadku <i>12</i>)
 
 Jeśli chcemy, żeby nasz element zajmował całą całą szerokość kontenera, zastosujemy kod
 ```html
@@ -69,7 +69,7 @@ Może być też tak, że bedzięmy chcieli utworzyć obok siebie 3 kolumny tej s
 	</div>   
 </div>                 
 ```  
-Tworząc layout możemy również budować kolumny o różnych szerokościach zawarte w obrębie tego samego rzędu. Pamiętajmy jednak, że maksymalnie możemy zmieścić 12 kolumn w jednym rzędzie tworząc różne kombinacje np. `8+4`,`7+5`,`2+2+3+5`, `9+2+1` itd. 
+Tworząc layout możemy również budować kolumny o różnych szerokościach zawarte w obrębie tego samego rzędu. Pamiętajmy jednak, że maksymalnie możemy zmieścić 12 kolumn w jednym rzędzie tworząc różne kombinacje np. `8+4`,`7+5`,`2+2+3+5`, `9+2+1` itd.
 
 ```html
 <div class="container">
@@ -78,15 +78,15 @@ Tworząc layout możemy również budować kolumny o różnych szerokościach za
 			szerokość zawierająca 8 kolumn siatki
         </div>
         <div class="col-md-4">
-        	szerokość zawierająca 4 kolumny siatki 
+        	szerokość zawierająca 4 kolumny siatki
         </div>
 	</div>   
 </div>                 
 ```  
 
 ### Budowanie siatki w zależności od szerokości urządzenia
-Zastanawiacie się pewnie jak uzyskać efekt zmiany szerokości różnych elementów layoutu w zależności od szerokości wyświetlacza.
-Przykładowo: chcielibyśmy, żeby dla wysokich i średnich rozdzielczości kolumna z definicją i zadaniem, zawarte były w dwóch, równych szerokością kolumnach. Niestety takie rozwiązanie niekorzystnie prezentuje się na telefonie, gdyż podział szerokości kontenera na pół, daje nam końcowo bardzo wąskie kolumny, w których ograniczona jest czytelność. Możemy wykorzystać wbudowaną właściwość siatki Boostrapowej nadając zawartości danego `<div>` różne szerokości w zależności od urządzenia, na którym wyświetlana jest strona. 
+Zastanawiacie się pewnie, jak uzyskać efekt zmiany szerokości różnych elementów layoutu w zależności od szerokości wyświetlacza.
+Przykładowo: chcielibyśmy, żeby dla wysokich i średnich rozdzielczości kolumna z definicją i zadaniem zawarte były w dwóch, równych szerokością kolumnach. Niestety, takie rozwiązanie niekorzystnie prezentuje się na telefonie, gdyż podział szerokości kontenera na pół daje nam ostatecznie bardzo wąskie kolumny, w których ograniczona jest czytelność. Możemy wykorzystać wbudowaną właściwość siatki boostrapowej nadając zawartości danego `<div>` różne szerokości w zależności od urządzenia, na którym wyświetlana jest strona.
 Co należy zrobić? Popatrzmy na kod poniżej.
 ```html
 <div class="container">
@@ -100,27 +100,27 @@ Co należy zrobić? Popatrzmy na kod poniżej.
 	</div>   
 </div>                 
 ```  
-Jak zauważyliście, dodane zostały nowe klasy `col-xs-12` - definiująca szerokość dla telefonu (dzieki czemu tekst będzie zajmował *12* kolumn) oraz `col-sm-12` - definiująca szerokość dla tabletu (tekst zajmie pół szerokości kontenera, czyli *6* kolumn). `col-md-12` definiuje nam zatem szerokość desktopową (typową dla wyświetlaczy laptopów > 992px). `col-lg-12` przypisany jest dla wyświetlaczy o rozdzielczości >= 1200 px, czyli laptopów o większym wyświetlaczu.
+Jak zauważyliście, dodane zostały nowe klasy `col-xs-12` – definiująca szerokość dla telefonu (dzieki czemu tekst będzie zajmował <i>12</i> kolumn) – oraz `col-sm-6` – definiująca szerokość dla tabletu (tekst zajmie pół szerokości kontenera, czyli <i>6</i> kolumn). `col-md-12` definiuje nam zatem szerokość desktopową (typową dla wyświetlaczy laptopów > 992px). `col-lg-12` przypisany jest dla wyświetlaczy o rozdzielczości >= 1200 px, czyli laptopów o większym wyświetlaczu.
 
 Zerknijcie na poniższą tabelę
 
-|  | Bardzo małe urządzenia <br>smartfony (<768px) | Małe urządzenia<br>tablety (≥768px) | Średnie urządzenia<br>tzw. desktop (≥992px) | Duże urządzenia<br>duże rozdzielczości (≥1200px) 
+|  | Bardzo małe urządzenia <br>smartfony (<768px) | Małe urządzenia<br>tablety (≥768px) | Średnie urządzenia<br>tzw. desktop (≥992px) | Duże urządzenia<br>duże rozdzielczości (≥1200px)
 | -------------- |:---:| :---:| :---:| :---:|
-| Prefix klasy       | `.col-xs-` | `.col-sm-` |`.col-md-`| `.col-lg-` | 
-| Szerokość kontenera       | brak (auto) | 750px | 960px | 1170px | 
+| Prefix klasy       | `.col-xs-` | `.col-sm-` |`.col-md-`| `.col-lg-` |
+| Szerokość kontenera       | brak (auto) | 750px | 960px | 1170px |
 
 
 
 > #### Exercise::Ćwiczenie 14
 >
 > Porą dołączyć plik CSS, zawierający grid pochodzący z Bootstrapa do naszego projektu Planty. Co warto podkreślić, na zajęciach wykorzystujemy jedynie siatkę bootstrapową. Nie będziemy zajmować się innymi komponentami z frameworku Boostrap.
-> <a href="../resources/bootstrap-grid.css" target="_blank">Ściągnij plik `bootstrap-grid.css`</a> i zapisz go do folderu ze stylami, czyli `styles`. Następnie dodaj plik do Twojego kodu HTML, korzystając ze znacznika 
+> <a href="../resources/bootstrap-grid.css" target="_blank">Ściągnij plik `bootstrap-grid.css`</a> i zapisz go do folderu ze stylami, czyli `styles`. Następnie dodaj plik do Twojego kodu HTML, korzystając ze znacznika
 >`<link href="tu wpisz ścieżkę do pliku css" rel="stylesheet">`. Pamiętaj o napisaniu prawidłowej ścieżki!
 > Pora na wypróbowanie jak działa siatka.
 > W kodzie HTML do Planty utwórz dwie, równe pod względem szerokości kolumny w sekcji zawierającej formularz.
 >
->Uzyskaj poniższy efekt, wykorzystując dotychczas zdobytą wiedzę. 
->Na razie nie przejmuj się pastelową ramką nałożoną na obrazek - w kolejnym rozdziale dowiesz się jak to zrobić.
+>Uzyskaj poniższy efekt, wykorzystując dotychczas zdobytą wiedzę.
+>Na razie nie przejmuj się pastelową ramką nałożoną na obrazek – w kolejnym rozdziale dowiesz się jak to zrobić.
 >
 ![Formularz w Plany z wykorzystaną siatką][3]
 [3]: /images/grid-form.png
@@ -134,11 +134,9 @@ Jeśli zrobiliście już ćwiczenie 14. i macie ochotę na podszlifowanie umięj
 > #### Exercise::Ćwiczenie 15* (dla chętnych)
 >
 >Oto następny layout do zakodowania.
->Załącz font pochodzący <a href="http://google.com/fonts" target="_blank">Google Fonts</a>, w tym projekcie jest to wspaniały krój **Lato** zaprojektowany przez Łukasza Dziedzica. Do nagłówków przyda się wersja <i>bold</i>, zaś do reszty tekstów wersja <i>regular</i>.
+>Załącz font pochodzący <a href="http://google.com/fonts" target="_blank">Google Fonts</a>. W tym projekcie jest to wspaniały krój **Lato** zaprojektowany przez Łukasza Dziedzica. Do nagłówków przyda się wersja <i>bold</i>, zaś do reszty tekstów wersja <i>regular</i>.
 >
-><a href="../resources/exercise-15/exercise-15.zip">Tutaj pobierzesz potrzebne assety</a> do zbudowania layoutu - obrazki oraz teksty na stronę.
+><a href="../resources/exercise-15/exercise-15.zip">Pobierz potrzebne assety</a> do zbudowania layoutu – obrazki oraz teksty na stronę.
 >
 ![Layout dla chętnych][4]
 [4]: /resources/exercise15-layout.jpg
-
-

--- a/pl/css-layout/css-positioning.md
+++ b/pl/css-layout/css-positioning.md
@@ -1,17 +1,17 @@
 ## Pozycjonujemy elementy na stronie
 
-Domyślnie elementy na stronie umieszczane są jeden za drugim (z uwzględnieniem wartości właściwości `display`). Czasem jednak zdarza się, że potrzebujemy uzyskać efekt nałożenia jednego elementu na drugi bądź przesunięcia. Na szczęście język CSS jest wyposażony w narzędzia, które nam to umożliwiają - są to właściwości związane z **pozycjonowaniem**.
+Domyślnie elementy na stronie umieszczane są jeden za drugim (z uwzględnieniem wartości właściwości `display`). Czasem jednak zdarza się, że potrzebujemy uzyskać efekt nałożenia jednego elementu na drugi bądź przesunięcia. Na szczęście język CSS jest wyposażony w narzędzia, które nam to umożliwiają. Są to właściwości związane z <b>pozycjonowaniem</b>.
 
 Do pozycjonowania służy właściwość `position`, która może przyjmować poniższe wartości:
 
-- `static` - jest to wartość domyślna dla każdego elementu, nie trzeba deklarować jej wprost.
-- `relative` - zmienia położenie elementu względem niego samego.
-- `absolute` - wyjmuje element z jego pierwotnego położenia i umieszcza go we wskazanym miejscu względem najbliższego kontenera, który ma zdefiniowane `position: relative`.
-- `fixed` - umieszcza element na stałej pozycji względem okna przeglądarki (*viewport*). Dobrym przykładem użycia jest menu na stałe "przyklejone" u góry strony.
+- `static` – jest to wartość domyślna dla każdego elementu, nie trzeba deklarować jej wprost.
+- `relative` – zmienia położenie elementu względem niego samego.
+- `absolute` – wyjmuje element z jego pierwotnego położenia i umieszcza go we wskazanym miejscu względem najbliższego kontenera, który ma zdefiniowane `position: relative`.
+- `fixed` – umieszcza element na stałej pozycji względem okna przeglądarki (<i>viewport</i>). Dobrym przykładem użycia jest menu na stałe "przyklejone" u góry strony.
 
 Oprócz deklaracji `position` musimy również zadeklarować wartości współrzędnych, dzięki którym możemy precyzyjnie określić położenie naszego elementu: `top`, `bottom`, `right` oraz `left`.
 
-Na prostych przykładach zobaczmy, jak opanować pozycjonowanie w CSS.
+Na prostych przykładach zobaczymy, jak opanować pozycjonowanie w CSS.
 
 ```html
 <div class="container">
@@ -45,7 +45,7 @@ Na prostych przykładach zobaczmy, jak opanować pozycjonowanie w CSS.
   <div style="width:150px;height:150px;background:salmon;margin:5px"></div>
 </div>
 
-Powyżej przykład elementu wypozycjonowamego relatywnie (czyli względem samego siebie). 
+Powyżej przykład elementu wypozycjonowamego relatywnie (czyli względem samego siebie).
 
 Pozycjonowanie absolutne wymaga od nas nieco ostrożności, jednak jeśli wiemy, jak działa, nie wpadniemy w żadną pułapkę.
 
@@ -81,7 +81,7 @@ Pozycjonowanie absolutne wymaga od nas nieco ostrożności, jednak jeśli wiemy,
   <div style="width:150px;height:150px;background:salmon;margin:5px"></div>
 </div>
 
-Powyższy element został wyjęty ze swojego miejsca (jak widać, nie pozostawia również po sobie wolnej przestrzeni - cóż za oszczędność!) i umieszczony zupełnie gdzie indziej - w prawym górnym rogu strony.
+Powyższy element został wyjęty ze swojego miejsca (jak widać, nie pozostawia również po sobie wolnej przestrzeni – cóż za oszczędność!) i umieszczony zupełnie gdzie indziej, w prawym górnym rogu strony.
 
 Jeśli używamy pozycjonowania absolutnego nieostrożnie, nasz element może wylądować w dość niespodziewanym miejscu. Musimy więc pamiętać, że każdy element z `position: absolute` jest pozycjonowany **względem** jakiegoś innego elementu. Takim odniesieniem jest najbliższy element, któremu nadaliśmy `position: relative`. Musimy też pamiętać, że element pozycjonowany absolutnie musi znajdować się **wewnątrz** elementu z `position: relative`.
 
@@ -136,4 +136,3 @@ Jeśli używamy pozycjonowania absolutnego nieostrożnie, nasz element może wyl
   <div style="width:100%;height:100px;margin:5px 0;background:salmon;position:relative;"><div style="width:50px;height:50px;background:lightblue;position:absolute;top:0;right:0"></div></div>
   <div style="width:100%;height:100px;margin:5px 0;background:salmon"></div>
 </div>
-

--- a/pl/css-rwd-basics/README.md
+++ b/pl/css-rwd-basics/README.md
@@ -1,28 +1,28 @@
 # Podstawy kodowania responsywnych stron
 
-W dzisiejszych czasach przeglądamy Internet nie tylko siedząc w domu przed biurkiem, ale też korzystając ze smartfona jadąc autobusem, spoglądając na smartwatcha albo przesuwając palcem po tablecie. Mnogość typów urządzeń, ich rozdzielczości wydaje się oszałamiająca i sprawia wrażenie, że zaprojektowanie i zakodowanie strony, która będzie się na każdym prawidłowo wyświetlać wydaje się niewykonalne.
+W dzisiejszych czasach przeglądamy Internet nie tylko siedząc w domu przed biurkiem, ale też korzystając ze smartfona jadąc autobusem, spoglądając na smartwatcha albo przesuwając palcem po tablecie. Mnogość typów urządzeń, ich rozdzielczości wydaje się oszałamiająca i sprawia wrażenie, że zaprojektowanie i zakodowanie strony, która będzie się na każdym prawidłowo wyświetlać, wydaje się niewykonalne.
 
-Bardzo ważne jest zatem, aby już na etapie projektowania, a także później kodowania zadbać o to, aby strona była responsywna. Termin *Responsive Web Design* [istnieje w obiegu już od 2010 roku](http://alistapart.com/article/responsive-web-design). Od tamtej pory zgromadzono całkiem spory zasób wiedzy na temat tego, jak dostosowywać strony do wyświetlania za pomocą różnych mediów.
+Bardzo ważne jest zatem, aby już na etapie projektowania, a także później kodowania, zadbać o to, aby strona była responsywna. Termin <i>Responsive Web Design</i> [istnieje w obiegu już od 2010 roku](http://alistapart.com/article/responsive-web-design). Od tamtej pory zgromadzono całkiem spory zasób wiedzy na temat tego, jak dostosowywać strony do wyświetlania za pomocą różnych mediów.
 
-Niestety, wyjaśnienie wszystkiego dogłębnie spowodowałoby, że objętość tego tutoriala podwoiłaby się, a wraz z nią i czas trwania naszego kursu. Zapoznajmy się zatem z podstawamy kodowania responsywnych stron i dowiedzmy się, czym są *media queries*.
+Niestety, wyjaśnienie wszystkiego dogłębnie spowodowałoby, że objętość tego tutoriala podwoiłaby się, a wraz z nią i czas trwania naszego kursu. Zapoznajmy się zatem z podstawami kodowania responsywnych stron i dowiedzmy się, czym są <i>media queries</i>.
 
 ## Zanim zaczniesz pisać kod CSS
 
-Upewnij się, że w nagłówku (`head`) pliku HTML znajduje się poniższy kod:
+Upewnij się, że w nagłówku pliku HTML (`<head>`) znajduje się poniższy kod:
 
 ```html
 <meta name="viewport" content="width=device-width, initial-scale=1">
 ```
 
-Właściwość `width` determinuje domyślną szerokość strony. Moglibyśmy wstępnie ustawić ją w pikselach, np. `width=800`, jednak jak można się domyślić nie prezentowałaby się najlepiej na urządzeniach o szerokości ekranu różnej od 800 pikseli. Wartość `device-width` oznacza tyle, że szerokość naszej strony ma dostosować się do szerokości wyświetlacza.
+Właściwość `width` określa domyślną szerokość strony. Moglibyśmy wstępnie ustawić ją w pikselach, np. `width=800`, jednak jak można się domyślić nie prezentowałaby się najlepiej na urządzeniach o szerokości ekranu różnej od 800 pikseli. Wartość `device-width` oznacza tyle, że szerokość naszej strony ma dostosować się do szerokości wyświetlacza.
 
-Właściwość `initial-scale=1` mówi przeglądarce, że tuż po załadowaniu strona powinna pokazać się bez powiększenia (*zoom*), w swojej naturalnej wielkości.
+Właściwość `initial-scale=1` mówi przeglądarce, że tuż po załadowaniu strona powinna pokazać się bez powiększenia (<i>zoom</i>), w swojej naturalnej wielkości.
 
 ## Kontrolowanie responsywnego layoutu za pomocą CSS
 
 Po zapoznaniu się z siatką zapewne zaczęliście się zastanawiać, jak to się dzieje, że elementy siatki mogą przyjmować różne szerokości dla różnych szerokości ekranu. Niektórzy z Was pewnie zajrzeli do kodu źródłowego i dostrzegli zagadkowe `@media`.
 
-Reguła `@media` umożliwia nam serwowanie różnych wartości styli w zależności od medium, na jakim wyświetlana jest strona. Możemy zastosować tę regułę również dla wydruku strony, ale nie tylko - [lista typów i właściwości mediów jest całkiem długa](https://developer.mozilla.org/en-US/docs/Web/CSS/@media).
+Reguła `@media` umożliwia nam serwowanie różnych wartości stylów w zależności od medium, na jakim wyświetlana jest strona. Możemy zastosować tę regułę również dla wydruku strony, ale nie tylko – [lista typów i właściwości mediów jest całkiem długa](https://developer.mozilla.org/en-US/docs/Web/CSS/@media).
 
 ```css
 /*
@@ -32,7 +32,7 @@ Reguła `@media` umożliwia nam serwowanie różnych wartości styli w zależno�
 @media screen and (max-width: 768px) {
  .class { ... }
 }
- 
+
 /*
   Style działające dla szerokości
   ekranu większej od 60em
@@ -40,10 +40,10 @@ Reguła `@media` umożliwia nam serwowanie różnych wartości styli w zależno�
 @media screen and (min-width: 60em) {
  .class1 { ... }
 }
- 
+
 /*
   Style dla ekranu pracującego w trybie
-  `landscape` i jednocześnie o podwójnej 
+  `landscape` i jednocześnie o podwójnej
   gęstości pikseli (ta gęstość pikseli jest
   charakterystyczna dla wyświetlaczy Retina)
 */
@@ -59,7 +59,7 @@ Reguła `@media` umożliwia nam serwowanie różnych wartości styli w zależno�
 }
 ```
 
-Istotne jest, aby wewnątrz nawiasów `@media { }` zawrzeć nie tylko same właściwości, ale całe deklaracje styli, łącznie z selektorami.
+Istotne jest, aby wewnątrz nawiasów `@media { }` zawrzeć nie tylko same właściwości, ale całe deklaracje stylów, łącznie z selektorami.
 
 ```css
 /*
@@ -82,22 +82,22 @@ Istotne jest, aby wewnątrz nawiasów `@media { }` zawrzeć nie tylko same wła�
 }
 ```
 
-W projektowaniu stron dość popularne jest podejście *mobile first*, czyli skupienie się w pierwszej kolejności na layoucie dla małych ekranów mobilnych urządzeń. Małe ekrany oznaczają mniej dostępnej przestrzeni i jednocześnie więcej ograniczeń dla projektanta lub programisty stron.
+W projektowaniu stron dość popularne jest podejście <i>mobile first</i>, czyli skupienie się w pierwszej kolejności na layoucie dla małych ekranów mobilnych urządzeń. Małe ekrany oznaczają mniej dostępnej przestrzeni i jednocześnie więcej ograniczeń dla projektanta lub programisty stron.
 
-W kodzie CSS oznacza to zaczęcie kodowania globalnych styli od tych, które będą działać dla urządzeń o małych ekranach i zawężanie zakresu styli potrzebnych dla urządzeń o większych ekranach za pomocą *media query* z `min-width`.
+W kodzie CSS oznacza to zaczęcie kodowania globalnych stylów od tych, które będą działać dla urządzeń o małych ekranach i zawężanie zakresu stylów potrzebnych dla urządzeń o większych ekranach za pomocą <i>media query</i> z `min-width`.
 W praktyce często oznacza to mniej napisanego kodu.
 
 ```css
 .mobile-first-component {
   width: 100%;
 }
- 
+
 @media screen and (min-width: 992px) {
    .mobile-first-component {
       width: 50%;
    }
 }
- 
+
 @media screen and (min-width: 1200px) {
    .mobile-first-component {
       width: 33%;

--- a/pl/css-specificity/README.md
+++ b/pl/css-specificity/README.md
@@ -6,8 +6,8 @@ W CSS możemy tworzyć złożone (kombinowane) selektory. Umożliwia to nam zaw�
 
 ```css
 
-/* 
-  Wybieram wszystkie elementy typu `a`, 
+/*
+  Wybieram wszystkie elementy typu `a`,
   których wartość atrybutu `href`
   to dokładnie `http://theawwwesomes.org`
 */
@@ -34,7 +34,7 @@ li.active {
 }
 ```
 
-Tak, jak wyżej - jeśli umieścimy obok siebie dwa (lub więcej) selektory (bez spacji!) oznacza to, że dane reguły CSS zostaną zastosowane dla elementów spełniających wszystkie te kryteria **jednocześnie**.
+Tak, jak wyżej – jeśli umieścimy obok siebie dwa (lub więcej) selektory (bez spacji!) oznacza to, że dane reguły CSS zostaną zastosowane dla elementów spełniających wszystkie te kryteria **jednocześnie**.
 
 Możemy również wskazywać na elementy według relacji, w jakich znajdują się wobec siebie w drzewie dokumentu HTML.
 
@@ -116,18 +116,18 @@ ul li a[href="http://theawwwesomes.org"] {
 }
 ```
 
-Mając tę świadomość, a także wiedząc, że style mogą pochodzić z różnych źródeł, w jaki sposób przeglądarka określa, jakie style mają zostać zastosowane dla naszego elementu? Aby odpowiedzieć na to pytanie, musimy zapoznać się z pojęciem [**specyficzności**](https://css-tricks.com/specifics-on-css-specificity/) (ang. *specificity*).
+Mając tę świadomość, a także wiedząc, że style mogą pochodzić z różnych źródeł, w jaki sposób przeglądarka określa, jakie style mają zostać zastosowane dla naszego elementu? Aby odpowiedzieć na to pytanie, musimy zapoznać się z pojęciem [<b>specyficzności</b>](https://css-tricks.com/specifics-on-css-specificity/) (ang. <i>specificity</i>).
 
 Każdy rodzaj selektora możemy umieścić na ściśle określonej pozycji w szeregu ważności. Wymieńmy je w kolejności od najmniej do najbardziej ważnych:
 
-1) Element oraz pseudo-element
+1) Element oraz pseudoelement
 
 ```css
 div { }
 p::after { }
 ```
 
-2) Klasa, pseudo-klasa oraz atrybut
+2) Klasa, pseudoklasa oraz atrybut
 
 ```css
 .container { }
@@ -140,13 +140,13 @@ p::after { }
 ```css
 #users-chart { }
 ```
-4) Styl zapisany *inline*
+4) Styl zapisany <i>inline</i>
 
 ```html
 <ul style="list-style-type: none"></ul>
 ```
 
-O tym, co to są pseudo-klasy i pseudo-elementy dowiemy się w późniejszych rozdziałach.
+O tym, co to są pseudoklasy i pseudoelementy dowiemy się w późniejszych rozdziałach.
 
 > ####Important::Ważne
 >
@@ -163,9 +163,9 @@ O tym, co to są pseudo-klasy i pseudo-elementy dowiemy się w późniejszych ro
 }
 ```
 >
-> W powyższym przykładzie tekst naszego paragrafu zostanie pokolorowany na szaro (`silver`), pomimo, że według reguł specyficzności to style `inline` powinny zyskać najwyższy priorytet.
+> W powyższym przykładzie tekst naszego akapitu zostanie pokolorowany na szaro (`silver`), pomimo że według reguł specyficzności to style `inline` powinny zyskać najwyższy priorytet.
 >
-> Musicie być bardzo ostrożni używając `!important`, ze względu na to, że takie style są bardzo trudne do nadpisania - bardzo łatwo o bałagan w kodzie. Radzimy Wam zatem, aby **unikać** używania tego słowa kluczowego jak tylko się da!
+> Musicie być bardzo ostrożni używając `!important`, ze względu na to, że takie style są bardzo trudne do nadpisania – bardzo łatwo o bałagan w kodzie. Radzimy Wam zatem, aby **unikać** używania tego słowa kluczowego jak tylko się da!
 
 Jeśli zatem na nasz element wskazuje kilka prostych selektorów, określenie, jakie style powinny zostać mu nadane jest całkiem proste. Jak sprawa ma się w przypadku selektorów kombinowanych? W tym wypadku specyficzność jest wyliczana bazując na 4-elementowej [krotce](https://pl.wikipedia.org/wiki/Krotka_%28struktura_danych%29):
 
@@ -173,12 +173,12 @@ Jeśli zatem na nasz element wskazuje kilka prostych selektorów, określenie, j
 0 0 0 0
 ```
 
-1) Dla każdego selektora elementu bądź pseudo-elementu zwiększ 4-ty element o 1.
+1) Dla każdego selektora elementu bądź pseudoelementu zwiększ 4-ty element o 1.
 ```css
 0 0 0 1
 ```
 
-2) Dla każdej klasy, pseudo-klasy lub atrybutu zwiększ 3-ci element o 1.
+2) Dla każdej klasy, pseudoklasy lub atrybutu zwiększ 3-ci element o 1.
 ```css
 0 0 1 0
 ```
@@ -224,12 +224,12 @@ ul li a[href="http://theawwwesomes.org"] {
 I obliczmy specyficzność naszych selektorów:
 
 ```css
-ul li a[href="http://theawwwesomes.org"] 
+ul li a[href="http://theawwwesomes.org"]
 
 /* Mamy tu 3 selektory elementu oraz 1 selektor atrybutu */
 0 0 1 3
 
-.main-nav li.active 
+.main-nav li.active
 
 /* Mamy tu 1 selektor elementu oraz 2 selektory klasy */
 0 0 2 1

--- a/pl/developer-tools/README.md
+++ b/pl/developer-tools/README.md
@@ -1,28 +1,28 @@
 # Narzędzia dewelopera stron internetowych
 
-Zanim przystąpicie do pisania pierwszych linijek kodu zaprzyjaźnijcie się z podstawowymi narzędziami kodera, czyli edytorem tekstu oraz przeglądarką!
+Zanim przystąpicie do pisania pierwszych linijek kodu, zaprzyjaźnijcie się z podstawowymi narzędziami kodera, czyli edytorem tekstu oraz przeglądarką!
 
 ## Edytor tekstowy
 
-Czy do kodowania stron będzie nam potrzebny jakiś specjalny rodzaj edytora? Być może moglibyśmy użyć do tego na przykład Worda, który przydaje się często do tworzenia dokumentów? Niestety, programy typu Word zapisują tekst w specjalny sposób, który umożliwia formatowanie tekstu (czyli m.in. zmianę wielkości, koloru albo kroju fonta) - jest to tzw. *[RTF (Rich Text Format)](https://pl.wikipedia.org/wiki/Rich_Text_Format)*.
+Czy do kodowania stron będzie nam potrzebny jakiś specjalny rodzaj edytora? Być może moglibyśmy użyć do tego na przykład Worda, który przydaje się często do tworzenia dokumentów? Niestety, programy typu Word zapisują tekst w specjalny sposób, który umożliwia formatowanie tekstu (czyli m.in. zmianę wielkości, koloru albo kroju fonta) - jest to tzw. <i>[RTF (Rich Text Format)](https://pl.wikipedia.org/wiki/Rich_Text_Format)</i>.
 
-Wasz kod natomiast musi być zapisany w postaci **zwykłego tekstu** (*plain text*), w związku z tym Word na pewno nie będzie dobrym wyborem jako edytor!
+Wasz kod natomiast musi być zapisany w postaci **zwykłego tekstu** (<i>plain text</i>), w związku z tym Word na pewno nie będzie dobrym wyborem jako edytor!
 
 Prostą stronę internetową możecie zakodować używając Notatnika lub innej domyślnej aplikacji, która umożliwia edycję zwykłych plików tekstowych. Nie jest to jednak najlepszy pomysł w dzisiejszych czasach. Pokażemy Wam, że używanie nieco bardziej zaawansowanych narzędzi nie jest takie straszne, a może bardzo ułatwić pracę.
 
-Kiedy już bardzo się wprawicie w programowaniu stron, na pewno Wasze potrzeby w stosunku do edytora kodu wzrosną - zarówno odnośnie wydajności jak i funkcjonalności. Zwykle w swojej codziennej pracy programiści korzystają z tzw. *IDE* (*Integrated Development Environment*, czyli **zintegrowanego środowiska programistycznego**), które potrafi bardzo przyspieszyć pracę. W tej chwili jednak nie musicie zajmować sobie tym głów!
+Kiedy już bardzo się wprawicie w programowaniu stron, na pewno Wasze potrzeby w stosunku do edytora kodu wzrosną – zarówno odnośnie wydajności jak i funkcjonalności. Zwykle w swojej codziennej pracy programiści korzystają z tzw. <i>IDE</i> (ang. <i>Integrated Development Environment</i>, czyli <b>zintegrowanego środowiska programistycznego</b>), które potrafi bardzo przyspieszyć pracę. W tej chwili jednak nie musicie zawracać sobie tym głów!
 
 > #### Exercise::Ćwiczenie 1
 >
->- Utwórz w dowolnym miejscu na dysku folder, w którym będziesz przechowywać efekty swojej pracy. 
->- Możesz go nazwać np. `the-awwwesomes`, a wewnątrz utworzyć podfolder `exercise-1` jako miejsce dla naszego pierwszego ćwiczenia.
+>- Utwórz w dowolnym miejscu na dysku folder, w którym będziesz przechowywać efekty swojej pracy.
+>- Możesz go nazwać np. `the-awwwesomes`, a wewnątrz utworzyć podfolder `exercise-1` – jako miejsce dla naszego pierwszego ćwiczenia.
 >- Otwórz Notatnik i utwórz w nim plik tekstowy o dowolnej zawartości (na przykład: `Witaj świecie!`).
->- Zapisz ten plik w utworzonym przed chwilą folderze pod nazwą `index.html`. Dokładnie tak! Zwróć uwagę, że nie zapisujemy go pod zwykłym rozszerzeniem `*.txt`. Chcemy w ten sposób zaznaczyć, że jest to specjalny plik, który może odczytać przeglądarka interentowa. O tym, czym tak naprawdę jest HTML opowiemy szerzej w kolejnym rozdziale.
+>- Zapisz ten plik w utworzonym przed chwilą folderze pod nazwą `index.html`. Dokładnie tak! Zwróć uwagę, że nie zapisujemy go pod zwykłym rozszerzeniem `*.txt`. Chcemy w ten sposób zaznaczyć, że jest to specjalny plik, który może odczytać przeglądarka interentowa. O tym, czym tak naprawdę jest HTML, opowiemy szerzej w kolejnym rozdziale.
 >- Otwórz plik `index.html` w przeglądarce i obejrzyj efekt swojej pracy!
 
 ## Sublime Text, czyli Twoje środowisko pracy
 
-Na początek polecamy [Sublime Text](https://www.sublimetext.com/3) - pobierzcie ze strony wersję odpowiednią dla Waszego systemu operacyjnego i zainstalujcie. Sublime Text, oprócz edycji kodu umożliwia m.in. podgląd struktury projektu oraz podświetlanie kodu. 
+Na początek polecamy [Sublime Text](https://www.sublimetext.com/3). Pobierzcie ze strony wersję odpowiednią dla Waszego systemu operacyjnego i zainstalujcie. Sublime Text, oprócz edycji kodu, umożliwia m.in. podgląd struktury projektu oraz podświetlanie kodu.
 
 Oto, jak prezentuje się kod strony [theawwwesomes.org](http://theawwwesomes.org) w Sublime Text 3:
 
@@ -31,43 +31,43 @@ Oto, jak prezentuje się kod strony [theawwwesomes.org](http://theawwwesomes.org
 > #### Exercise::Ćwiczenie 2
 >
 >- Po zainstalowaniu otwórz Sublime Text.
->- Z menu wybierz `Plik -> Otwórz folder...` i przejdź do folderu, w którym zapisałeś przed chwilą `index.html`
->- Po lewej zobaczysz widok struktury folderu. Rozwijając folder możesz zobaczyć jego zawartość, czyli jak na razie jest to tylko `index.html`. Możesz otworzyć go w widoku edycji po lewej (klikając dwukrotnie na jego nazwę).
+>- Z menu wybierz `Plik → Otwórz folder…` i przejdź do folderu, w którym zapisałeś przed chwilą `index.html`.
+>- Po lewej stronie zobaczysz widok struktury folderu. Rozwijając folder możesz zobaczyć jego zawartość, czyli jak na razie tylko plik `index.html`. Możesz otworzyć go w widoku edycji, klikając dwukrotnie na jego nazwę.
 
-## Narzędzia dewelopera w przeglądarce stron internetowych
+## Narzędzia deweloperskie w przeglądarce stron internetowych
 
-Być może kiedyś, kiedy korzystaliście z jakiejś aplikacji na swoim komputerze lub smartfonie kusiło Was, aby podejrzeć jej kod. Jeśli akurat nie było to otwarte oprogramowanie, to treść tego kodu pozostała tajemnicą dla Was, jako zwykłych użytkowników.
+Być może kiedyś, kiedy korzystaliście z jakiejś aplikacji na swoim komputerze lub smartfonie, kusiło Was, aby podejrzeć jej kod. Jeśli akurat nie było to otwarte oprogramowanie, to treść tego kodu pozostała tajemnicą dla Was, jako zwykłych użytkowników.
 
-Ze stronami internetowymi sytuacja przedstawia się nieco inaczej. Będąc zwykłym odbiorcą, który czyta wiadomości przy śniadaniu, możecie podejrzeć kod strony i zobaczyć, w jaki sposób została zakodowana! Niemożliwe? Wchodząc na dowolną stronę, klikając prawym przyciskiem myszy ukaże się menu kontekstowe. W tym menu powinna znajdować się pozycja `Wyświetl źródło strony` (lub `Pokaż źródło strony`, w zależności od przeglądarki). Po kliknięciu na nią Waszym oczom powinien ukazać się wtedy blok kodu źródłowego strony. To jednak nie koniec możliwości przeglądarki w badaniu kodu stron.
+Ze stronami internetowymi sytuacja przedstawia się nieco inaczej. Będąc zwykłym odbiorcą, który czyta wiadomości przy śniadaniu, możecie podejrzeć kod strony i zobaczyć, w jaki sposób została zakodowana! Niemożliwe? Wchodząc na dowolną stronę, klikając prawym przyciskiem myszy ukaże się menu kontekstowe. W tym menu powinna znajdować się pozycja `Wyświetl źródło strony` (lub `Pokaż źródło strony`, w zależności od przeglądarki). Po kliknięciu na nią Waszym oczom powinien ukazać się wtedy blok kodu źródłowego strony. To jednak nie koniec możliwości przeglądarki w zakresie badania kodu stron.
 
-Praca programisty byłaby prosta, a jego życie usłane różami, gdyby wszystkie linijki kodu działały prawidłowo, a rezultaty były przewidywalne. Niestety, jak pewnie się domyślacie tak nie jest. Kiedy kod nie działa tak, jak trzeba, bardzo przydatna jest wiedza na temat tego, jak znaleźć przyczynę błędu. Proces szukania błędów w kodzie nazywamy [debugowaniem](https://pl.wikipedia.org/wiki/Debugowanie).
+Praca programisty byłaby prosta, a jego życie usłane różami, gdyby wszystkie linijki kodu działały prawidłowo, a rezultaty ich działania – przewidywalne. Niestety, jak pewnie się domyślacie, tak nie jest. Kiedy kod nie działa tak, jak trzeba, bardzo przydatna jest wiedza na temat tego, jak znaleźć przyczynę błędu. Proces szukania błędów w kodzie nazywamy [debugowaniem](https://pl.wikipedia.org/wiki/Debugowanie).
 
 > #### Important::Ważne
 >
->Koder stron w swojej pracy do debugowania używa narzędzi deweloperskich wbudowanych w przeglądarkę. Aby z nich skorzystać, wystarczy wcisnąć F12 dla Windowsa lub kombinację klawiszy Cmd+Alt+I dla OS X (Mac) kiedy wyświetlacie dowolną stronę. Oto, jak narzędzia deweloperskie wyglądają w najpopularniejszych przeglądarkach:
+>Koder stron w swojej pracy do debugowania używa narzędzi deweloperskich wbudowanych w przeglądarkę. Aby z nich skorzystać, wystarczy w trakcie przeglądania dowolnej strony WWW wcisnąć klawisz <kbd>F12</kbd> w Windowsie lub kombinację klawiszy <kbd>Cmd+Alt+I</kbd> w macOS-ie. Oto jak narzędzia deweloperskie wyglądają w najpopularniejszych przeglądarkach:
 >
 >- Chrome:
 >
->![Narzędzia dewelopera Chrome](/images/chrome-devtools.png "Narzędzia dewelopera Chrome")
+>![Narzędzia deweloperskie w Chrome](/images/chrome-devtools.png "Narzędzia deweloperskie w  Chrome")
 >
 >- Firefox:
 >
->![Narzędzia dewelopera Firefox](/images/ff-devtools.png "Narzędzia dewelopera Firefox")
+>![Narzędzia deweloperskie w Firefoksie](/images/ff-devtools.png "Narzędzia deweloperskie w Firefoksie")
 >
 >- Internet Explorer:
 >
->![Narzędzia dewelopera Internet Explorer](/images/ie-devtools.png "Narzędzia dewelopera Internet Explorer")
+>![Narzędzia deweloperskie w Internet Explorerze](/images/ie-devtools.png "Narzędzia deweloperskie w Internet Explorerze")
 
-Dla ustalenia uwagi od tej pory skupimy się na narzędziach deweloperskich w Chrome. Jak widać, wszystkie z powyższych są do siebie podobne (również w funkcjonalności), jednak naszym zdaniem Google Chrome oferuje najwygodniejsze i najbardziej funkcjonalne narzędzia.
+Dla jasności ustalmy, że od tej pory skupimy się na narzędziach deweloperskich w Chrome. Jak widać, wszystkie narzędzia deweloperskie są do siebie podobne (również w funkcjonalności), jednak naszym zdaniem Google Chrome oferuje najwygodniejsze i najbardziej funkcjonalne narzędzia.
 
 ### Jak poruszać się w narzędziach deweloperskich?
 
-Dopóki nie posiadacie wiedzy na temat kodu HTML i CSS, poruszanie się w *devtoolsach* może wydawać się Wam prawdziwą *czarną magią*. Na początek pokażemy Wam tylko najbardziej podstawowe funkcjonalności, a wraz z nabywaniem nowych umiejętności będziecie się już coraz sprawniej odnajdować w korzystaniu z narzędzi programistycznych.
+Dopóki nie posiadacie wiedzy na temat kodu HTML i CSS, poruszanie się w <i>devtools</i> może wydawać się Wam prawdziwą *czarną magią*. Na początek pokażemy Wam tylko najbardziej podstawowe możliwości, a wraz z nabywaniem nowych umiejętności będziecie się już coraz sprawniej odnajdować w korzystaniu z narzędzi programistycznych.
 
-Zauważyliście pewnie, że *devtoolsy* zawierają dużo przycisków i zakładek. Jednak na potrzeby warsztatów i kodowania tylko w HTML i CSS będziemy korzystać właściwie tylko z jednej - *Elementy* (*Elements*).
+Zauważyliście pewnie, że <i>devtools</i> zawierają dużo przycisków i zakładek. Jednak na potrzeby warsztatów i kodowania tylko w HTML i CSS będziemy korzystać właściwie tylko z jednej – <b>Elementy</b> (<i>Elements</i>).
 
-Wejdźcie na swoją ulubioną stronę (może to być portal z wiadomościami albo Facebook) i za pomocą F12 dla Windowsa lub Cmd+Alt+I dla OS X (Mac) otwórzcie narzędzia deweloperskie. W sekcji po prawej możecie zobaczyć narzędzie *Inspektor kodu HTML*. Spróbujcie chwilę poeksperymentować i wypróbować intuicyjnie jego możliwości. Na pewno zauważycie, że po najechaniu myszą na jedną z *gałęzi* podświetlony zostanie odpowiadający jej element na stronie.
+Wejdźcie na swoją ulubioną stronę (może to być portal z wiadomościami albo Facebook) i za pomocą klawisza <kbd>F12</kbd> w Windowsie lub kombinacji klawiszy <kbd>Cmd+Alt+I</kbd> w macOS-ie otwórzcie narzędzia deweloperskie. W sekcji po prawej stronie możecie zobaczyć narzędzie <b>Inspektor kodu HTML</b>. Spróbujcie chwilę poeksperymentować i wypróbować jego możliwości. Na pewno zauważycie, że po najechaniu myszą na jedną z <i>gałęzi</i>, podświetlony zostanie odpowiadający jej element na stronie.
 
-W lewym górnym rogu widnieje ikonka ![Wybierz element na stronie aby go zbadać](/images/inspector-ico.png "Wybierz element na stronie aby go zbadać") - po jej kliknięciu uruchomicie *tryb inspektora*. W tym trybie możecie wybierać elementy bezpośrednio na stronie i podglądać ich kod w narzędziach deweloperskich. Oprócz kodu HTML można w ten sposób badać również style CSS. Służy do tego sekcja po prawej stronie. Więcej na temat badania styli dowiecie się w rozdziałach poświęconych językowi CSS.
+W lewym górnym rogu widnieje ikonka ![Wybierz element na stronie, aby go zbadać](/images/inspector-ico.png "Wybierz element na stronie, aby go zbadać") – po jej kliknięciu uruchomicie <i>tryb inspektora</i>. W tym trybie możecie wybierać elementy bezpośrednio na stronie i podglądać ich kod w narzędziach deweloperskich. Oprócz kodu HTML można w ten sposób badać również style CSS. Służy do tego sekcja po prawej stronie. Więcej na temat badania stylów dowiecie się w rozdziałach poświęconych językowi CSS.
 
 Podsumowując, od tej pory Waszymi przyjaciółmi staną się edytor tekstowy i narzędzia deweloperskie! Nie obawiajcie się używać ich, aby podglądać i weryfikować efekty swojej pracy.

--- a/pl/how-internet-works/README.md
+++ b/pl/how-internet-works/README.md
@@ -6,11 +6,11 @@
 
 Możemy się założyć, że używacie go każdego dnia. Ale czy naprawdę wiecie co się dzieje, gdy wpisujecie w przeglądarce adres http://theawwwesomes.org i wciskacie *enter*?
 
-Aby zrozumieć jak działa Internet powinniście najpierw dowiedzieć się czym tak naprawdę jest strona internetowa, a jest ona tylko zbiorem plików zapisanych na dysku twardym. Tak samo jak Wasze zdjęcia, muzyka czy filmy. Aczkolwiek strony internetowe różnią się od nich tym, że zawierają kod komputerowy zwany HTML.
+Aby zrozumieć jak działa Internet, powinniście najpierw dowiedzieć się czym tak naprawdę jest strona internetowa, a jest ona tylko zbiorem plików zapisanych na dysku twardym. Tak samo jak Wasze zdjęcia, muzyka czy filmy. Aczkolwiek strony internetowe różnią się od nich tym, że zawierają kod komputerowy zwany HTML.
 
-Jeśli nie mieliście wcześniej do czynienia z programowaniem, może być Wam na początku trudno zrozumieć HTML, ale przeglądarki internetowe (takie jak Chrome, Safari, Firefox itd.) uwielbiają go. Zostały one zaprojektowane po to, by czytać ten kod, przetwarzać go i postępować zgodnie z jego instrukcjami. Prezentują pliki, z których składa się Twoja strona - by wyglądała dokładnie tak jak Ty chcesz.
+Jeśli nie mieliście wcześniej do czynienia z programowaniem, może być Wam na początku trudno zrozumieć HTML, ale przeglądarki internetowe (takie jak Chrome, Safari, Firefox itd.) uwielbiają go. Zostały one zaprojektowane po to, by czytać ten kod, przetwarzać go i postępować zgodnie z jego instrukcjami. Prezentują pliki, z których składa się Twoja strona – by wyglądała dokładnie tak jak Ty chcesz.
 
-Tak jak w przypadku każdego innego pliku, musimy umiejscowić pliki HTML na dysku twardym. Do przechowywania plików HTML używamy specjalnych, potężnych komputerów zwanych *serwerami (ang. servers)*. Serwery nie posiadają monitorów, myszy ani klawiatur, ich głównym celem jest przechowywanie danych i serwowanie ich. Dlatego są one nazywane *serwerami* - ponieważ służą do *serwowania* danych.
+Tak jak w przypadku każdego innego pliku, musimy umiejscowić pliki HTML na dysku twardym. Do przechowywania plików HTML używamy specjalnych, potężnych komputerów zwanych *serwerami (ang. servers)*. Serwery nie posiadają monitorów, myszy ani klawiatur, ich głównym celem jest przechowywanie danych i serwowanie ich. Dlatego są one nazywane *serwerami* – ponieważ służą do *serwowania* danych.
 
 Ok, ale pewnie chcielibyście wiedzieć jak wygląda Internet?
 
@@ -26,7 +26,7 @@ Wygląda dość chaotycznie, prawda? W rzeczywistości jest to sieć połączony
 
  [2]: /images/submarine-map.png
 
-To fascynujące, prawda? Ale oczywiście niemożliwe jest stworzenie bezpośredniego połączenia kablowego między każdym komputerem w Internecie. Więc aby dostać się do maszyny dostępnej w Internecie (na przykład tej, na której zapisane jest http://theawwwesomes.org) potrzebujemy wykonać zapytanie przechodzące przez wiele, wiele różnych maszyn.
+To fascynujące, prawda? Ale oczywiście niemożliwe jest stworzenie bezpośredniego połączenia kablowego między każdym komputerem w Internecie. Więc aby dostać się do maszyny dostępnej w Internecie (na przykład tej, na której zapisane jest http://theawwwesomes.org), potrzebujemy wykonać zapytanie przechodzące przez wiele, wiele różnych maszyn.
 
 Wygląda to tak:
 
@@ -36,7 +36,7 @@ Wygląda to tak:
 
 Wyobraźcie sobie, że po wpisaniu http://theawwwesomes.org, wysyłacie list o treści: "Drodzy Awwwesomes, chcę zobaczyć stronę *theawwwesomes.org*. Wyślijcie ją do mnie, proszę!"
 
-List trafia do urzędu pocztowego najbliżej Was. Potem idzie do drugiego urzędu, który znajduje się trochę bliżej Waszego adresata. Potem do kolejnego, kolejnego, kolejnego, aż w końcu zostanie doręczony do miejsca przeznaczenia. Ciekawa rzecz - jeśli wyślecie wiele listów (*pakietów danych*) do tego samego adresata, mogą przejść przez zupełnie inne urzędy pocztowe (*routery*). To zależy od tego w jaki sposób zostaną rozdzielone w każdym urzędzie.
+List trafia do urzędu pocztowego najbliżej Was. Potem idzie do drugiego urzędu, który znajduje się trochę bliżej Waszego adresata. Potem do kolejnego, kolejnego, kolejnego, aż w końcu zostanie doręczony do miejsca przeznaczenia. Ciekawa rzecz: jeśli wyślecie wiele listów (*pakietów danych*) do tego samego adresata, mogą przejść przez zupełnie inne urzędy pocztowe (*routery*). To zależy od tego w jaki sposób zostaną rozdzielone w każdym urzędzie.
 
 ![Wysyłamy list][4]
 

--- a/pl/how-internet-works/README.md
+++ b/pl/how-internet-works/README.md
@@ -4,13 +4,13 @@
 >
 > Bardzo dziękujemy twórcom [tutoriala Django Girls](http://tutorial.djangogirls.org/pl/) za udostępnienie nam tekstu rozdziału!
 
-Możemy się założyć, że używacie go każdego dnia. Ale czy naprawdę wiecie co się dzieje, gdy wpisujecie w przeglądarce adres http://theawwwesomes.org i wciskacie *enter*?
+Możemy się założyć, że używacie go każdego dnia. Ale czy naprawdę wiecie co się dzieje, gdy wpisujecie w przeglądarce adres http://theawwwesomes.org i wciskacie <kbd>Enter</kbd>?
 
 Aby zrozumieć jak działa Internet, powinniście najpierw dowiedzieć się czym tak naprawdę jest strona internetowa, a jest ona tylko zbiorem plików zapisanych na dysku twardym. Tak samo jak Wasze zdjęcia, muzyka czy filmy. Aczkolwiek strony internetowe różnią się od nich tym, że zawierają kod komputerowy zwany HTML.
 
 Jeśli nie mieliście wcześniej do czynienia z programowaniem, może być Wam na początku trudno zrozumieć HTML, ale przeglądarki internetowe (takie jak Chrome, Safari, Firefox itd.) uwielbiają go. Zostały one zaprojektowane po to, by czytać ten kod, przetwarzać go i postępować zgodnie z jego instrukcjami. Prezentują pliki, z których składa się Twoja strona – by wyglądała dokładnie tak jak Ty chcesz.
 
-Tak jak w przypadku każdego innego pliku, musimy umiejscowić pliki HTML na dysku twardym. Do przechowywania plików HTML używamy specjalnych, potężnych komputerów zwanych *serwerami (ang. servers)*. Serwery nie posiadają monitorów, myszy ani klawiatur, ich głównym celem jest przechowywanie danych i serwowanie ich. Dlatego są one nazywane *serwerami* – ponieważ służą do *serwowania* danych.
+Tak jak w przypadku każdego innego pliku, musimy umiejscowić pliki HTML na dysku twardym. Do przechowywania plików HTML używamy specjalnych, potężnych komputerów zwanych <i>serwerami</i> (ang. <i>servers</i>). Serwery nie posiadają monitorów, myszy ani klawiatur, ich głównym celem jest przechowywanie danych i serwowanie ich. Dlatego są one nazywane <i>serwerami</i> – ponieważ służą do *serwowania* danych.
 
 Ok, ale pewnie chcielibyście wiedzieć jak wygląda Internet?
 
@@ -20,7 +20,7 @@ Narysowaliśmy Ci schemat Internetu! Wygląda tak:
 
  [1]: /images/img1-2.png
 
-Wygląda dość chaotycznie, prawda? W rzeczywistości jest to sieć połączonych między sobą maszyn (wspomnianych wyżej *serwerów*). Setki tysięcy maszyn! Wiele, wiele kilometrów kabli na całym świecie! Możecie wejść na stronę [Submarine Cable Map](http://submarinecablemap.com) i sami zobaczyć jak skomplikowana jest ta sieć. Oto zrzut ekranu ze strony internetowej:
+Wygląda dość chaotycznie, prawda? W rzeczywistości jest to sieć połączonych między sobą maszyn (wspomnianych wyżej <i>serwerów</i>). Setki tysięcy maszyn! Wiele, wiele kilometrów kabli na całym świecie! Możecie wejść na stronę [Submarine Cable Map](http://submarinecablemap.com) i sami zobaczyć jak skomplikowana jest ta sieć. Oto zrzut ekranu ze strony internetowej:
 
 ![Submarine Cable Map][2]
 
@@ -34,9 +34,9 @@ Wygląda to tak:
 
  [3]: /images/img1-3.png
 
-Wyobraźcie sobie, że po wpisaniu http://theawwwesomes.org, wysyłacie list o treści: "Drodzy Awwwesomes, chcę zobaczyć stronę *theawwwesomes.org*. Wyślijcie ją do mnie, proszę!"
+Wyobraźcie sobie, że po wpisaniu http://theawwwesomes.org, wysyłacie list o treści: "Drodzy Awwwesomes, chcę zobaczyć stronę <b>theawwwesomes.org</b>. Wyślijcie ją do mnie, proszę!"
 
-List trafia do urzędu pocztowego najbliżej Was. Potem idzie do drugiego urzędu, który znajduje się trochę bliżej Waszego adresata. Potem do kolejnego, kolejnego, kolejnego, aż w końcu zostanie doręczony do miejsca przeznaczenia. Ciekawa rzecz: jeśli wyślecie wiele listów (*pakietów danych*) do tego samego adresata, mogą przejść przez zupełnie inne urzędy pocztowe (*routery*). To zależy od tego w jaki sposób zostaną rozdzielone w każdym urzędzie.
+List trafia do urzędu pocztowego najbliżej Was. Potem idzie do drugiego urzędu, który znajduje się trochę bliżej Waszego adresata. Potem do kolejnego, kolejnego, kolejnego, aż w końcu zostanie doręczony do miejsca przeznaczenia. Ciekawa rzecz: jeśli wyślecie wiele listów (<i>pakietów danych</i>) do tego samego adresata, mogą przejść przez zupełnie inne urzędy pocztowe (<i>routery</i>). To zależy od tego w jaki sposób zostaną rozdzielone w każdym urzędzie.
 
 ![Wysyłamy list][4]
 
@@ -46,6 +46,6 @@ Tak, to takie proste. Wysyłacie wiadomości i oczekujecie jakiejś odpowiedzi. 
 
 Zamiast adresów z nazwą ulicy, miastem, kodem pocztowym oraz nazwą kraju, używa się adresów IP. Wasze komputery najpierw pytają serwer DNS (system nazw domenowych, ang. DNS - Domain Name System) o przetłumaczenie theawwwesomes.org na adres IP. Działa to podobnie do dawnych książek telefonicznych, w których mogliście poszukać adresu czy numeru po nazwisku osoby, z którą chcieliście się skontaktować.
 
-Listy muszą spełniać konkretne warunki, żeby zostały poprawnie doręczone: muszą posiadać adres, znaczek itd. Muszą być też napisane językiem zrozumiałym dla odbiorcy. To samo dotyczy *pakietów danych*, które wysyłacie, by zobaczyć jakąś stronę. Używany jest protokół HTTP (Hypertext Transfer Protocol).
+Listy muszą spełniać konkretne warunki, żeby zostały poprawnie doręczone: muszą posiadać adres, znaczek itd. Muszą być też napisane językiem zrozumiałym dla odbiorcy. To samo dotyczy <i>pakietów danych</i>, które wysyłacie, by zobaczyć jakąś stronę. Używany jest protokół HTTP (Hypertext Transfer Protocol).
 
-Tak więc, ogólnie rzecz ujmując, jeśli chcecie mieć swoją stronę internetową musicie mieć *serwer* (komputer), gdzie będzie ona funkcjonować. Gdy *serwer* odbiera przychodzące *żądania* (Wasz list), wysyła Wam w odpowiedzi Waszą stronę (kolejny list).
+Tak więc, ogólnie rzecz ujmując, jeśli chcecie mieć swoją stronę internetową musicie mieć <i>serwer</i> (komputer), gdzie będzie ona funkcjonować. Gdy <i>serwer</i> odbiera przychodzące <i>żądania</i> (Wasz list), wysyła Wam w odpowiedzi Waszą stronę (kolejny list).

--- a/pl/html-code/README.md
+++ b/pl/html-code/README.md
@@ -1,19 +1,19 @@
 # Kod HTML
 
-Uwaga, uwaga, zapnijcie pasy, bo przechodzimy wreszcie do konkretów! Za chwilę napiszecie swój pierwszy kod HTML, jesteście już podekscytowani? 
+Uwaga, uwaga! Zapnijcie pasy, bo przechodzimy wreszcie do konkretów! Za chwilę napiszecie swój pierwszy kod HTML. Jesteście już podekscytowani?
 
 ## Co powinien zawierać prawidłowy kod HTML?
 
 Jak wygląda HTML w akcji? Spójrzcie poniżej, przygotowaliśmy dla Was przykładowy kod kompletnej strony:
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html lang="pl-PL">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Darmowe warsztaty z programowania HTML i CSS.">
-    <title>The Awwwesomes - Darmowe warsztaty z programowania HTML & CSS</title>
+    <title>The Awwwesomes – Darmowe warsztaty z programowania HTML & CSS</title>
     <link rel="stylesheet" href="/styles/website.css">
   </head>
   <body>
@@ -54,7 +54,7 @@ Deklaracja `DOCTYPE` mówi nam o wersji i typie dokumentu HTML. Nie ma znaczenia
 </html>
 ```
 
-- Wewnątrz tagów `<html>` wyróżniamy dwie sekcje: `<head>`, czyli "głowa" dokumentu, w której będziemy umieszczać *metadane* oraz `<body>`, która zawiera całą treść dokumentu.
+- Wewnątrz tagów `<html>` wyróżniamy dwie sekcje: `<head>`, czyli "głowę" dokumentu, w której będziemy umieszczać <i>metadane</i> oraz `<body>`, która zawiera całą treść dokumentu.
 
 ```html
 <html>
@@ -74,7 +74,7 @@ Deklaracja `DOCTYPE` mówi nam o wersji i typie dokumentu HTML. Nie ma znaczenia
 
 Co to takiego są [metadane](https://pl.wikipedia.org/wiki/Metadane)? W tym przypadku są to wszystkie informacje istotne dla strony jednak niewidoczne bezpośrednio w jej treści. Kilka przykładów:
 
-- Znacznika `<title>` używamy do podania tytułu strony, który jest zwykle widoczny na górnej belce przeglądarki, jako tytuł karty oraz w wynikach wyszukiwania strony.
+- Znacznika `<title>` używamy do podania tytułu strony, który jest zwykle widoczny na górnej belce przeglądarki jako tytuł karty, oraz w wynikach wyszukiwania strony.
 
 ```html
 <title>Moja pierwsza strona internetowa</title>
@@ -86,15 +86,15 @@ Co to takiego są [metadane](https://pl.wikipedia.org/wiki/Metadane)? W tym przy
 <meta charset="utf-8">
 ```
 
-Powyższa wartość atrybutu ustawia kodowanie dokumentu na [UTF-8](https://pl.wikipedia.org/wiki/UTF-8). Jest to szczególnie ważne, kiedy chcemy używać na naszej stronie polskich (i nie tylko polskich) znaków diakrytycznych.
+Powyższa wartość atrybutu `charset` ustawia kodowanie dokumentu na [UTF-8](https://pl.wikipedia.org/wiki/UTF-8). Jest to szczególnie ważne, kiedy chcemy używać na naszej stronie polskich (i nie tylko polskich) znaków diakrytycznych.
 
 ```html
 <meta name="viewport" content="width=device-width, initial-scale=1">
-``` 
+```
 
-Użycie atrybutów `name` oraz `content` dokładnie w powyższy sposób pozwala nam na [zoptymalizowanie naszej strony do wyświetlania na urządzeniach mobilnych](https://developer.mozilla.org/pl/docs/Mozilla/Mobile/Viewport_meta_tag). Dzięki temu strona pojawi się w oknie mobilnej przeglądarki dokładnie w rozmiarze dostępnego okna. Nie są to wszystkie działania niezbędne do tego, aby witryna wyświetlała się dobrze. Jest to znacznie szerszy temat, zwany *[Responsive Web Design](https://developer.mozilla.org/pl/docs/Mozilla/Mobile/Viewport_meta_tag)*, czyli projektowanie stron responsywnych.
+Użycie atrybutów `name` oraz `content` w powyższy sposób pozwala nam na [zoptymalizowanie naszej strony do wyświetlania na urządzeniach mobilnych](https://developer.mozilla.org/pl/docs/Mozilla/Mobile/Viewport_meta_tag). Dzięki temu strona pojawi się w oknie mobilnej przeglądarki dokładnie w rozmiarze dostępnego okna. Nie są to wszystkie działania niezbędne do tego, aby witryna wyświetlała się dobrze. Jest to znacznie szerszy temat, zwany <i>[Responsive Web Design](https://developer.mozilla.org/pl/docs/Mozilla/Mobile/Viewport_meta_tag)<i>, czyli <i>projektowanie stron responsywnych</i>.
 
-- Za pomocą atrybutu `<link>` możemy załączyć do naszego dokumentu na przykład plik `*.css`.
+- Za pomocą atrybutu `<link>` możemy załączyć do naszego dokumentu zewnętrzne zasoby, na przykład plik `*.css`.
 
 ```html
  <link rel="stylesheet" href="/styles/website.css">
@@ -137,7 +137,7 @@ Użycie atrybutów `name` oraz `content` dokładnie w powyższy sposób pozwala 
 >
 > Strona zawiera artykuł, który składa się z nagłówka, daty publikacji, obrazka i treści. Pod artykułem znajduje się prosty formularz do dodawania komentarzy. Jak przenieść wymienione elementy do kodu HTML?
 >
-> Na początku zadbamy, aby otrzymać w efekcie prawidłowy kod HTML. W tej chwili nie przejmuj się jeszcze tym, jak powinny być kodowane poszczególne elementy, czyli np. nagłówki bądź paragrafy.
+> Na początku zadbamy, aby otrzymać w efekcie prawidłowy kod HTML. W tej chwili nie przejmuj się jeszcze tym, jak powinny być kodowane poszczególne elementy, czyli np. nagłówki bądź akapity.
 > - W folderze `the-awwwesomes` stwórz podfolder `exercise-3`, w którym będziesz przechowywał wynik ćwiczenia. Otwórz ten folder w Sublime Text i utwórz w nim plik `index.html`.
-> - W pliku `index.html` utwórz szkielet strony, który zawiera wszystkie wymienione wyżej niezbędne elementy, takie, jak `doctype`, `<title>` bądź znaczniki `<meta>`.
+> - W pliku `index.html` utwórz szkielet strony, który zawiera wszystkie wymienione wyżej niezbędne elementy, takie, jak `DOCTYPE`, `<title>` bądź znaczniki `<meta>`.
 > - Podstawową treść strony umieść wewnątrz znaczników `<body>` jako zwykły tekst. Otwórz `index.html` w przeglądarce. Co widzisz? Czego brakuje?

--- a/pl/html-code/README.md
+++ b/pl/html-code/README.md
@@ -54,6 +54,8 @@ Deklaracja `DOCTYPE` mówi nam o wersji i typie dokumentu HTML. Nie ma znaczenia
 </html>
 ```
 
+Można zauważyć, że nasz znacznik `<html>` posiada atrybut `lang`. Określa on język, w jakim napisana jest treść strony.
+
 - Wewnątrz tagów `<html>` wyróżniamy dwie sekcje: `<head>`, czyli "głowę" dokumentu, w której będziemy umieszczać <i>metadane</i> oraz `<body>`, która zawiera całą treść dokumentu.
 
 ```html

--- a/pl/html-document-structure/README.md
+++ b/pl/html-document-structure/README.md
@@ -15,9 +15,9 @@ Spróbujmy pogrupować jej zawartość i wyróżnić główne elementy znajdują
 [2]: /images/page-layout-example-sections.png
 
 
-W pierwszej kolejności rzuca się w oczy **nagłówek** strony (oraz **stopka**, która akurat nie jest widoczna na naszym zrzucie ekranu). Moglibyśmy w tym momencie pójść o krok dalej i w nagłówku strony wyróżnić, na przykład, menu służące do **nawigacji**.
+W pierwszej kolejności rzuca się w oczy <b>nagłówek</b> strony (oraz <b>stopka</b>, która akurat nie jest widoczna na naszym zrzucie ekranu). Moglibyśmy w tym momencie pójść o krok dalej i w nagłówku strony wyróżnić, na przykład, menu służące do <b>nawigacji</b>.
 
-Pod nagłówkiem (a w zasadzie pomiędzy nagłówkiem a stopką) znajduje się główna zawartość strony. Jej najważniejszym elementem jest **artykuł**. Artykuł składa się z **nagłówka** oraz treści, która złożona jest z **ilustracji** oraz **akapitów tekstu**. W nagłówku artykułu możemy wyróżnić **tytuł** i **podtytuł**, a także informacje dotyczące autora oraz daty publikacji. Obok artykułu widzimy listę innych popularnych artykułów, która jest **elementem pobocznym** ponieważ nie dotyczy bezpośrednio głównej zawartości strony.
+Pod nagłówkiem (a w zasadzie pomiędzy nagłówkiem a stopką) znajduje się główna zawartość strony. Jej najważniejszym elementem jest <b>artykuł</b>. Artykuł składa się z <b>nagłówka</b> oraz treści, która złożona jest z <b>ilustracji</b> oraz <b>akapitów</b>. W nagłówku artykułu możemy wyróżnić <b>tytuł</b> i <b>podtytuł</b>, a także informacje dotyczące autora oraz daty publikacji. Obok artykułu widzimy listę innych popularnych artykułów, która jest <b>elementem pobocznym</b>, ponieważ nie dotyczy bezpośrednio głównej zawartości strony.
 
 Do wszystkich wymienionych powyżej elementów możemy zastosować odpowiednie znaczniki HTML.
 
@@ -56,7 +56,7 @@ Dzięki znacznikom `<header>` i `<footer>` możemy określić, że dany element 
 
 Tak, jak pokazaliśmy w przykładzie wyżej, znacznika `<nav>` używamy kiedy chcemy zaznaczyć, że wewnątrz danego elementu znajduje się nawigacja strony. Może być on użyty więcej niż raz w obrębie tego samego dokumentu.
 
-Znacznik `<aside>` pozwala nam na określenie danego elementu jako nie powiązanego ściśle tematycznie z główną zawartością strony, choć wciąż ważnego z punktu widzenia odbiorcy. Klasycznym przykładem są tu reklamy umieszczane na stronie.
+Znacznik `<aside>` pozwala nam na określenie danego elementu jako niepowiązanego ściśle tematycznie z główną zawartością strony, choć wciąż ważnego z punktu widzenia odbiorcy. Klasycznym przykładem są tu reklamy umieszczane na stronie.
 
 Tag `<article>` jest przydatny dla elementów takich jak artykuł na blogu lub stronie z wiadomościami, post na forum albo komentarz pozostawiony pod artykułem.
 
@@ -68,7 +68,7 @@ Nie wymieniliśmy powyżej jeszcze jednego ważnego znacznika, który pomaga nam
 <section>Jestem sekcją strony</section>
 ```
 
-Znacznik `<section>` ma już nieco bardziej ogólne zastosowanie - używamy go, aby tematycznie pogrupować naszą zawartość. Zwykle każda z tak uzyskanych sekcji powinna posiadać nagłówek odpowiedniego poziomu (`<h1>`-`<h6>`).
+Znacznik `<section>` ma już nieco bardziej ogólne zastosowanie. Używamy go, aby tematycznie pogrupować naszą zawartość. Zwykle każda z tak uzyskanych sekcji powinna posiadać nagłówek odpowiedniego poziomu (`<h1>`-`<h6>`).
 
 Sekcje z powodzeniem mogą być zagnieżdżane wewnątrz siebie.
 
@@ -109,11 +109,11 @@ Sekcje z powodzeniem mogą być zagnieżdżane wewnątrz siebie.
 > #### Exercise::Ćwiczenie 5
 >
 > Otwórz [stronę z artykułem](https://www.theguardian.com/technology/2016/apr/23/facebook-global-takeover-f8-conference-messenger-chatbots), która była źródłem przykładu z początku tego rozdziału.
-> - Uruchom narzędzia deweloperskie. Spróbuj obadać różne elementy strony i sprawdzić, jakich znaczników użyli autorzy strony i w jakich celach?
+> - Uruchom narzędzia deweloperskie. Spróbuj zbadać różne elementy strony i sprawdzić, jakich znaczników użyli autorzy strony i w jakich celach?
 
 ### Elementy generyczne (ogólne)
 
-*"Pomocy! Muszę zakodować element na stronie, jednak nie jestem w stanie dopasować jego znaczenia do żadnego z powyższych tagów!"*
+"Pomocy! Muszę zakodować element na stronie, jednak nie jestem w stanie dopasować jego znaczenia do żadnego z powyższych tagów!"
 
 Właśnie w takich przypadkach na ratunek spieszą nam elementy generyczne.
 
@@ -125,11 +125,11 @@ Właśnie w takich przypadkach na ratunek spieszą nam elementy generyczne.
 <span>Jestem generycznym elementem liniowym</span>
 ```
 
-Dokładnie tak - z pewnością niejednokrotnie znajdziecie się w sytuacji, kiedy zajdzie potrzeba zakodowania elementu, jednak w morzu tagów HTML nie znajdzie się żaden pasujący do roli. Wtedy użycie *elementów generycznych* nie będzie błędem.
+Z pewnością niejednokrotnie znajdziecie się w sytuacji, kiedy zajdzie potrzeba zakodowania jakiegoś elementu, jednak w morzu tagów HTML nie znajdzie się żaden pasujący do roli. Wtedy użycie <i>elementów generycznych</i> nie będzie błędem.
 
-W przykładzie powyżej widzicie aż dwa ich rodzaje. Skąd w ogóle podział na elementy liniowe i blokowe, co on oznacza?
+W przykładzie powyżej widzicie aż dwa ich rodzaje: blokowy oraz liniowy. Skąd w ogóle podział na elementy blokowe i liniowe i co on oznacza?
 
-W wielkim skrócie: **elementy liniowe** to takie, które zachowują się tak, jak linie tekstu. Naszego powyższego znacznika `<span>` możemy z powodzeniem użyć, aby "owinąć" nim fragment paragrafu i nie spowoduje to złamania linii.
+W wielkim skrócie: <b>elementy liniowe</b> to takie, które zachowują się tak, jak linie tekstu. Naszego powyższego znacznika `<span>` możemy z powodzeniem użyć, aby "owinąć" nim fragment akapitu i nie spowoduje to złamania linii.
 
 ```html
 <p>Jestem paragrafem tekstu, który zawiera domyślny <span>element liniowy.</span> Tutaj jest kontynuacja tekstu.</p>
@@ -139,7 +139,7 @@ W wielkim skrócie: **elementy liniowe** to takie, które zachowują się tak, j
   <p>Jestem paragrafem tekstu, który zawiera domyślny <span>element liniowy.</span> Tutaj jest kontynuacja tekstu.</p>
 </div>
 
-Jeśli umieścimy w naszym kodznie **element blokowy**, spowoduje on złamanie linii - zawartość elementu blokowego zostanie wyświetlona w nowej linii.
+Jeśli umieścimy w naszym kodznie <b>element blokowy</b>, spowoduje on złamanie linii – zawartość elementu blokowego zostanie wyświetlona w nowej linii.
 
 ```html
 <p>Jestem paragrafem tekstu, który zawiera domyślny <div>element blokowy.</div> Tutaj jest kontynuacja tekstu.</p>
@@ -155,7 +155,7 @@ Dobrą praktyką jest, aby nie umieszczać elementów blokowych wewnątrz liniow
 >
 > Pamiętaj, aby nie używać znacznika `<section>` jako generycznego kontenera "do wszystkiego"! `<section>`, jak już wspomnieliśmy, pozwala nam na tematyczne grupowanie zawartości strony. Natomiast `<div>` jest znacznikiem, który powinien być używany tylko w przypadkach, kiedy żaden inny znacznik nie będzie odpowiedni dla zawartości.
 
-Temat "czym różnią się elementy liniowe od blokowych" jest bardzo związany z prezentacją elementów na stronie i rozwiniemy go w odpowiednim rozdziale poświęconym stylom CSS.
+Temat "czym różnią się elementy liniowe od blokowych" jest związany z prezentacją elementów na stronie i rozwiniemy go w odpowiednim rozdziale poświęconym stylom CSS.
 
 > #### Exercise::Ćwiczenie 6
 >
@@ -166,6 +166,6 @@ Temat "czym różnią się elementy liniowe od blokowych" jest bardzo związany 
 > - W folderze `the-awwwesomes` (który jest przeznaczony na przechowywanie folderów ze wszystkimi ćwiczeniami) stwórz folder `planty`. Od tej pory to właśnie w tym folderze będziesz umieszczać wszystkie pliki dotyczące layoutu.
 > - Wewnątrz `the-awwwesomes/planty/` utwórz plik `index.html`. Będziesz tam tworzyć kod strony.
 > - Stwórz szkielet dokumentu HTML dbając, aby zawrzeć wszystkie potrzebne metadane w sekcji `<head>`.
-> - Bazując na projekcie layoutu oceń, jak należy pogrupować poszczególne elementy layoutu. Użyj odpowiednich znaczników. Pamiętaj, że budowanie layoutu można rozwiązać na różne sposoby, więc nie zrażaj się, jeśli Twój kod będzie różnił się od kodu koleżanek i kolegów. W budowaniu szkieletu warto rozrysować sobie layout na kartce w postaci kontenerów, nadając im odpowiednie znaczenie. 
+> - Bazując na projekcie layoutu oceń, jak należy pogrupować poszczególne elementy layoutu. Użyj odpowiednich znaczników. Pamiętaj, że budowanie layoutu można rozwiązać na różne sposoby, więc nie zrażaj się, jeśli Twój kod będzie różnił się od kodu koleżanek i kolegów. W budowaniu szkieletu warto rozrysować sobie layout na kartce w postaci kontenerów, nadając im odpowiednie znaczenie.
 > - Rozpocznij pracę nad kodem HTML strony. Zadbaj o to, aby dla każdego elementu użyć odpowiednich znaczników.
 > - Przygotowaliśmy dla Ciebie <a href="../resources/planty-assets/planty-assets.zip">paczkę z zasobami do pobrania</a>, które ułatwią Ci zadanie w razie potrzeby np. załączenia obrazka lub skopiowania tekstu.

--- a/pl/html-elements/README.md
+++ b/pl/html-elements/README.md
@@ -89,6 +89,10 @@ Można powiedzieć, że hiperłącza są solą Internetu!
 
 Użycie `target="_blank"` spowoduje, że strona, do której prowadzi Wasz link, zostanie otwarta w nowej karcie przeglądarki.
 
+> #### Important::Ważne
+>
+> W Sieci trwa nieustanna debata nad tym, czy atrybut `target` i wymuszanie otwierania strony w nowej karcie powinny być używane. [Bardzo wiele osób](http://www.forumweb.pl/forumweb-pl/drobne-pomysly/516489#516489) wskazuje na fakt, że jest to [odbieranie kontroli użytkownikowi](https://kornel.ski/pl/target).
+
 ## Obrazki
 
 Obrazki w kodzie wstawiamy za pomocą znacznika `<img>`. Jest on <i>pustym elementem</i> i nie posiada znacznika zamykającego. Dwa najważniejsze atrybuty, jakie może przyjmować `<img>` to:

--- a/pl/html-elements/README.md
+++ b/pl/html-elements/README.md
@@ -154,7 +154,7 @@ Obrazki w kodzie wstawiamy za pomocą znacznika `<img>`. Jest on <i>pustym eleme
 > i tak dalej.
 > Ścieżki bezwględne będą bardzo przydatne np. przy podłączniu pliku, zawierającego style. Przetestujemy to już niebawem podczas nauki o CSS.
 
-- `alt` służy do definiowania pomocniczego tekstu, który zostanie wyświetlony w przypadku, kiedy obrazek z różnych powodów nie zostanie poprawnie załadowany.
+- `alt` służy do definiowania pomocniczego tekstu, który zostanie wyświetlony w przypadku, kiedy obrazek z różnych powodów nie zostanie poprawnie załadowany. Jest też używany przez <i>[czytniki ekranowe](https://pl.wikipedia.org/wiki/Czytnik_ekranowy)</i> do informowania osób niewidomych lub niedowidzących o zawartości konkretnej ilustracji. Tym samym `alt` jest jednym z **podstawowych elementów [<i>dostępności stron WWW</i>](https://pl.wikipedia.org/wiki/Dost%C4%99pno%C5%9B%C4%87_(WWW))**.
 
 ```html
 <img src="images/example-img.jpg" alt="Uczymy się kodować">

--- a/pl/html-elements/README.md
+++ b/pl/html-elements/README.md
@@ -2,19 +2,19 @@
 
 Właśnie napisaliście swój pierwszy kod HTML, gratulacje! Kiedy jednak spojrzycie na niego, poza podstawowym szkieletem zawiera on jednolity blok tekstu. Brakuje nam wyróżnienia nagłówków, hiperłączy, obrazka i formularzy. Pora na zapoznanie Was z różnymi znacznikami HTML.
 
-Wiemy już, że aby uzyskać HTML-owy element należy "owinąć" go w *tagi* (*znaczniki*). Nie poznaliśmy jednak jak dotąd żadnych nazw znaczników, których moglibyśmy użyć na rzeczywistym przykładzie strony.
+Wiemy już, że aby uzyskać HTML-owy element należy "owinąć" go w <i>tagi</i> (<i>znaczniki</i>). Nie poznaliśmy jednak jak dotąd żadnych nazw znaczników, których moglibyśmy użyć na rzeczywistym przykładzie strony.
 
 ## Komentarze
 
-Często bywa tak, że kod jednej strony edytuje przynajmniej kilku programistów. Zdarza się też, że trzeba wrócić do kodu, który został napisany dość dawno temu. W takich przypadkach bywa, że pojawiają się niejasności i pytania *"Co autor miał na myśli?"*.
+Często bywa tak, że kod jednej strony edytuje przynajmniej kilku programistów. Zdarza się też, że trzeba wrócić do kodu, który został napisany dość dawno temu. W takich przypadkach bywa, że pojawiają się niejasności i pytania "Co autor miał na myśli?".
 
-Pomocne bywają nam wtedy komentarze. Są one ignorowane przez przeglądarkę podczas wyświetlania strony i widoczne tylko podczas podglądania jej kodu źródłowego. Komentarze bywają bardzo użyteczne przy opisie kodu i umożliwiają jego dokumentowanie.
+Pomocne dla nas bywają wtedy komentarze. Są one ignorowane przez przeglądarkę podczas wyświetlania strony i widoczne tylko podczas podglądania jej kodu źródłowego. Komentarze są bardzo użyteczne przy opisie kodu i umożliwiają jego dokumentowanie.
 
 ```html
 <!-- To jest komentarz do naszego kodu -->
 ```
 
-## Nagłówki i paragrafy
+## Nagłówki i akapity
 
 Tak samo, jak w dokumentach tekstowych, w HTML-u możemy zdefiniować nagłówki dla naszego tekstu:
 
@@ -42,7 +42,7 @@ Co zostanie zinterpretowane przez przeglądarkę jako:
 >
 > Pamiętajcie, że numery nagłówków nie odnoszą się do rozmiaru wyrenderowanego tekstu, ale oznaczają **hierarchię** zawartości.
 
-Przy okazji omawiania składni CSS napomknęliśmy o znaczniku `p`. Jego nazwa pochodzi od słowa *paragraph* - służy do definiowania akapitów w tekście.
+Przy okazji omawiania składni CSS napomknęliśmy o znaczniku `<p>`. Jego nazwa pochodzi od słowa <i>paragraph<i>, a on sam służy do definiowania akapitów w tekście.
 
 ```html
 <p>To jest akapit tekstu. Możesz w nim umieścić tekst dowolnej długości.</p>
@@ -52,9 +52,9 @@ Przy okazji omawiania składni CSS napomknęliśmy o znaczniku `p`. Jego nazwa p
   <p>To jest akapit tekstu. Możesz w nim umieścić tekst dowolnej długości.</p>
 </div>
 
-Paragrafy zwykle prezentowane są w przeglądarce jako bloki tekstu, wizualnie odseparowane od siebie pionowym odstępem.
+Akapity zwykle prezentowane są w przeglądarce jako bloki tekstu, wizualnie odseparowane od siebie pionowym odstępem.
 
-Kiedy kodujesz paragrafy tekstu, czasem zachodzi potrzeba złamania linii w określonym miejscu. Warto wiedzieć, że nie wystarczy tam wcisnąć *enter* w edytorze tekstu - do łamania linni w HTML-u służy specjalny znacznik `<br>`:
+Kiedy kodujesz akapity, czasem zachodzi potrzeba złamania linii w określonym miejscu. Warto wiedzieć, że nie wystarczy tam wcisnąć <kbd>Enter</kbd> w edytorze tekstu – do łamania linii w HTML-u służy specjalny znacznik `<br>`:
 
 ```html
 <p>Jestem bardzo długim tekstem, który nie mieści się w jednej linii, <br> zatem muszę zostać złamany.</p>
@@ -69,11 +69,11 @@ Kiedy kodujesz paragrafy tekstu, czasem zachodzi potrzeba złamania linii w okre
 
 > #### Important::Ważne
 >
-> Nie stosuj znacznika `<br>` aby wizualnie odseparować od siebie elementy w pionie! HTML powinien być używany **wyłącznie do definiowania treści**. W tym przypadku należy nadać elementom **pionowe marginesy za pomocą CSS** (już niedługo dowiecie się dokładnie, jak to zrobić).
+> Nie stosuj znacznika `<br>`, aby wizualnie odseparować od siebie elementy w pionie! HTML powinien być używany **wyłącznie do definiowania treści**. W tym przypadku należy nadać elementom **pionowe marginesy za pomocą CSS** (już niedługo dowiecie się dokładnie, jak to zrobić).
 
 ## Hiperłącza
 
-Dzięki hiperłączom (czyli po prostu linkom) możemy przenieść się w niemal dowolne inne miejsce w sieci. Link możecie umieścić na stronie używając znacznika `<a>` (od angielskiego słowa *anchor*) - podając adres linkowanej strony jako wartość atrybutu `href`.
+Dzięki hiperłączom (czyli po prostu linkom) możemy przenieść się w niemal dowolne inne miejsce w sieci. Link możecie umieścić na stronie używając znacznika `<a>` (od angielskiego słowa <i>anchor</i>) i podając adres linkowanej strony jako wartość atrybutu `href`.
 
 Można powiedzieć, że hiperłącza są solą Internetu!
 
@@ -87,28 +87,28 @@ Można powiedzieć, że hiperłącza są solą Internetu!
   <a href="http://theawwwesomes.org" target="_blank">Przeniosę Cię na stronę The Awwwesomes!</a>
 </div>
 
-Użycie `target="_blank"` spowoduje, że strona, do której prowadzi Wasz link zostanie otwarta w nowej karcie przeglądarki.
+Użycie `target="_blank"` spowoduje, że strona, do której prowadzi Wasz link, zostanie otwarta w nowej karcie przeglądarki.
 
 ## Obrazki
 
-Obrazki w kodzie wstawiamy za pomocą znacznika `<img>`. Jest on *pustym* elementem i nie posiada znacznika zamykającego. Dwa najważniejsze atrybuty, jakie może przyjmować `<img>` to:
+Obrazki w kodzie wstawiamy za pomocą znacznika `<img>`. Jest on <i>pustym elementem</i> i nie posiada znacznika zamykającego. Dwa najważniejsze atrybuty, jakie może przyjmować `<img>` to:
 
-- `src`, który zawiera ścieżkę do obrazka na dysku serwera lub w sieci. Jeśli wskazuje on na ścieżkę na dysku, zwykle jest to ścieżka względna - względem pliku HTML w którym znajduje się konkretny element `<img>`.
+- `src`, który zawiera ścieżkę do obrazka na dysku serwera lub w sieci. Jeśli wskazuje on na ścieżkę na dysku, zwykle jest to ścieżka względna – względem pliku HTML w którym znajduje się konkretny element `<img>`.
 
 > #### Important::Ważne
 >
-> W tym momencie chcemy zwrócić Waszą uwagę na ścieżki do zasobów (nie tylko obrazków, niedługo zaczniemy dołączać do naszej strony arkusze styli).
+> W tym momencie chcemy zwrócić Waszą uwagę na ścieżki do zasobów (nie tylko obrazków, niedługo zaczniemy dołączać do naszej strony arkusze stylów).
 > **Ścieżka bezwzględna** to taka, która zawiera pełny adres internetowy do zasobu, wraz z domeną.
 > ```html
  <img src="http://theawwwesomes.org/images/example.png" alt="Jestem obrazkiem ze ścieżką bezwzględną">
  ```
- > W zasadzie moglibyśmy w tym momencie zakończyć temat ścieżek i przestać zawracać sobie tym głowę. Jednak co się stanie, kiedy adres strony ulegnie zmianie? Musielibyśmy wtedy pozmieniać adresy do wszystkich obrazków na naszej stronie - bardzo dużo roboty!
- > Z pomocą przychodzi nam linkowanie za pomocą **ścieżek względnych**, czyli wskazywanie na położenie zasobu w systemie plików względem miejsca, w którym przechowujemy plik `html` z naszą stroną.
- > Najprostszym przykładem jest ten, kiedy plik grafiki oraz plik ze stroną znajdują się w tym samym miejscu (folderze):
+ > W zasadzie moglibyśmy w tym momencie zakończyć temat ścieżek i przestać zawracać sobie tym głowę. Jednak co się stanie, kiedy adres strony ulegnie zmianie? Musielibyśmy wtedy pozmieniać adresy do wszystkich obrazków na naszej stronie – bardzo dużo roboty!
+ > Z pomocą przychodzi nam linkowanie za pomocą <b>ścieżek względnych</b>, czyli wskazywanie na położenie zasobu w systemie plików względem miejsca, w którym przechowujemy plik `html` z naszą stroną.
+ > Najprostszym przykładem jest ten, w którym plik grafiki oraz plik ze stroną znajdują się w tym samym miejscu (folderze):
  > ```html
  <img src="example.png" alt="Jestem w tym samym folderze, co strona">
  ```
- > Jednak wrzucanie plików z różnymi zasobami do tego samego folderu mogłoby spowodować w krótkim czasie spory bałagan. Zwykle tworzymy specjalne podfoldery - osobny dla obrazków (możemy go nazwać np. `images`), dla plików ze stylami oraz skryptami JavaScript.
+ > Jednak wrzucanie plików z różnymi zasobami do tego samego folderu mogłoby spowodować w krótkim czasie spory bałagan. Zwykle tworzymy specjalne podfoldery – osobny dla obrazków (możemy go nazwać np. `images`), dla plików ze stylami, dla skryptów JavaScript itp..
  > Spróbujmy w prosty sposób zobrazować strukturę katalogu plików (dla uproszczenia uwzględnimy tylko obrazki):
  > ```html
  /my-website
@@ -126,9 +126,9 @@ Obrazki w kodzie wstawiamy za pomocą znacznika `<img>`. Jest on *pustym* elemen
 > ```html
  <img src="images/apples.png" alt="Tu widzimy jabłka">
  ```
-> Możemy się również odwoływać do zasobów znajdujących się w strukturze folderów "wyżej". Używamy wtedy w ścieżce charakterystycznych dwóch kropek `../`. 
+> Możemy się również odwoływać do zasobów znajdujących się w strukturze folderów "wyżej". Używamy wtedy w ścieżce charakterystycznych dwóch kropek `../`.
 >
-> Przykładowo - plik `index.html`, w którym piszemy kod html znajduje się folderze `/html` umieszczonym w `/my-website`, a `/images` stanowi podfolder `/my-website`. 
+> Przykładowo: plik `index.html`, w którym piszemy kod html, znajduje się folderze `/html` umieszczonym w `/my-website`, a `/images` stanowi podfolder `/my-website`.
 > ```html
  /my-website
   |-- /html
@@ -147,7 +147,7 @@ Obrazki w kodzie wstawiamy za pomocą znacznika `<img>`. Jest on *pustym* elemen
 > ```html
  <img src="../../images/apples.png" alt="Tu widzimy jabłka">
  ```
-> ... i tak dalej.
+> i tak dalej.
 > Ścieżki bezwględne będą bardzo przydatne np. przy podłączniu pliku, zawierającego style. Przetestujemy to już niebawem podczas nauki o CSS.
 
 - `alt` służy do definiowania pomocniczego tekstu, który zostanie wyświetlony w przypadku, kiedy obrazek z różnych powodów nie zostanie poprawnie załadowany.
@@ -197,4 +197,4 @@ Za pomocą znacznika `<ul>` definiujemy listy nieuporządkowanych elementów, na
 
 Pomimo, że najbardziej intuicyjnym (i oczywiście poprawnym) przypadkiem użycia list jest wyliczenie w tekście, znaczników listy możemy używać na przykład do definiowania elementów menu strony.
 
-Powyżej przedstawiliśmy Wam najczęściej używane znaczniki - a to zdecydowanie [nie wszystkie](https://developer.mozilla.org/en/docs/Web/HTML/Element)! W kolejnych rozdziałach dowiecie się natomiast, jak kodować proste formularze oraz określać strukturę dokumentu.
+Powyżej przedstawiliśmy Wam najczęściej używane znaczniki – a to zdecydowanie [nie wszystkie](https://developer.mozilla.org/en/docs/Web/HTML/Element)! W kolejnych rozdziałach dowiecie się natomiast, jak kodować proste formularze oraz określać strukturę dokumentu.

--- a/pl/html-forms/README.md
+++ b/pl/html-forms/README.md
@@ -1,6 +1,6 @@
 # Proste formularze
 
-Na pewno niejednokrotnie zdarzyło się Wam, korzystając ze strony internetowej, podawać swoje dane (na przykład, dokonując zakupu w sklepie internetowym) albo dodawać komentarze pod artykułem. HTML, oprócz tego, że umożliwia nam wyświetlanie zawartości strony pobranej z serwera, pozwala również na takie podstawowe interakcje, jak *wypełnianie formularzy*.
+Na pewno niejednokrotnie zdarzyło się Wam, korzystając ze strony internetowej, podawać swoje dane (na przykład dokonując zakupu w sklepie internetowym) albo dodawać komentarze pod artykułem. HTML, oprócz tego, że umożliwia nam wyświetlanie zawartości strony pobranej z serwera, pozwala również na takie podstawowe interakcje, jak <i>wypełnianie formularzy</i>.
 
 ## Jak wstawić formularz na stronę?
 
@@ -16,7 +16,7 @@ Kiedy umieszczamy na stronie formularz, najpierw musimy "powiedzieć" przegląda
 
 Wiedząc, jak zadeklarować sam formularz, możemy po kolei zapoznać się z różnymi rodzajami kontrolek.
 
-### Podstawowe interaktywne kontrolki (`input`)
+### Podstawowe interaktywne kontrolki (`<input>`)
 
 Załóżmy, że chcemy umieścić w naszym formularzu kilka prostych pól, dzięki którym użytkownik będzie mógł podać swoje imię, nazwisko oraz miejsce zamieszkania. Spójrzcie na kod poniżej:
 
@@ -28,11 +28,11 @@ Załóżmy, że chcemy umieścić w naszym formularzu kilka prostych pól, dzię
   <input type="text">
 </div>
 
-Znacznik `input` w większości przypadków służy do przyjmowania od użytkownika danych tekstowych (choć z powodzeniem możecie też wpisywać tam również liczby oraz znaki specjalne!). Musimy jednak pamiętać, że zachowanie pola `input` jest zależne od jego typu, który podajemy za pomocą atrybutu `type`. Dla pola tekstowego będzie to wyglądało jak powyżej: `type="text"`.
+Znacznik `<input>` w większości przypadków służy do przyjmowania od użytkownika danych tekstowych (choć z powodzeniem możecie wpisywać tam również liczby oraz znaki specjalne!). Musimy jednak pamiętać, że zachowanie pola `<input>` jest zależne od jego typu, który podajemy za pomocą atrybutu `type`. Dla pola tekstowego będzie to wyglądało jak powyżej: `type="text"`.
 
-Wygląda bardzo prosto, prawda? Tak prosto, że użytkownik nie widzi informacji o tym, jakich danych się od niego oczekuje. 
+Wygląda bardzo prosto, prawda? Tak prosto, że użytkownik nie widzi informacji o tym, jakich danych się od niego oczekuje.
 
-Do opisu pól formularza używamy znacznika `<label>` i właśnie wewnątrz niego umieszczamy informacje, co powinno znajdować się w danym polu:
+Do opisu pól formularza używamy znacznika `<label>` i właśnie wewnątrz niego umieszczamy informację, co powinno znajdować się w danym polu:
 
 ```html
 <label for="name">Podaj swoje imię:</label>
@@ -47,15 +47,15 @@ Do opisu pól formularza używamy znacznika `<label>` i właśnie wewnątrz nieg
 Zauważcie, że pojawiły się dwa nowe atrybuty: `id` oraz `for`.
 
 - Atrybut `id` jest identyfikatorem elementu HTML. Jego wartość musi być **unikalna** w obrębie całej strony. Atrybut `id` nie jest charakterystyczny tylko dla pól typu `<input>`, może być używany wraz z *dowolnym* znacznikiem HTML.
-- Atrybut `for` jest już charakterystyczny dla znacznika `<label>`. Łączy on `<label>` wraz z kontrolką formularza, której dotyczy. W takim wypadku wartość atrybutu `for` musi być *identyczna* jak wartość `id` pola tekstowego, do którego się odnosi. Dokładnie tak, jak w przykładzie powyżej.
+- Atrybut `for` jest już charakterystyczny dla znacznika `<label>`. Łączy on `<label>` wraz z kontrolką formularza, której dotyczy. W takim wypadku wartość atrybutu `for` musi być **identyczna** jak wartość `id` pola tekstowego, do którego się odnosi. Dokładnie tak, jak w przykładzie powyżej.
 
-A teraz zapoznajmy się teraz z pozostałymi typami pola `<input>`!
+A teraz zapoznajmy się z pozostałymi typami pola `<input>`!
 
 #### Kontrolki do podawania danych o określonym formacie
 
-Zapoznaliśmy się przed chwilą ze zwykłym polem tekstowym - do którego można wpisać w zasadzie dowolny ciąg znaków. Często jednak dane, jakich oczekujemy od użytkownika, muszą być podane w specjalnym formacie. Takim przypadkiem jest na przykład adres e-mail.
+Zapoznaliśmy się przed chwilą ze zwykłym polem tekstowym, do którego można wpisać w zasadzie dowolny ciąg znaków. Często jednak dane, jakich oczekujemy od użytkownika, muszą być podane w specjalnym formacie. Takim przypadkiem jest na przykład adres e-mail.
 
-Od niedawna (wraz z pojawieniem się specyfikacji HTML5) programiści WWW zyskali taką możliwość, ponieważ HTML został wzbogacony o nowe, specjalne typy kontrolek na potrzeby wprowadzania adresów e-mail, adresów stron internetowych, dat, numerów oraz wiele innych.
+Od niedawna (wraz z pojawieniem się specyfikacji HTML5) programiści WWW zyskali taką możliwość, ponieważ HTML został wzbogacony o nowe, specjalne typy kontrolek na potrzeby wprowadzania adresów e-mail, adresów stron internetowych, dat, numerów oraz wielu innych formatów.
 
 ```html
 <label for="emailData">Adres e-mail:</label>
@@ -87,7 +87,7 @@ Od niedawna (wraz z pojawieniem się specyfikacji HTML5) programiści WWW zyskal
 
 #### Pola wielokrotnego wyboru
 
-Pola wielokrotnego wyboru, czyli checkboksy. Dla tego typu pól atrybut `type` przyjmie wartość `checkbox`:
+Pola wielokrotnego wyboru, czyli <i>checkboksy</i>. Dla tego typu pól atrybut `type` przyjmie wartość `checkbox`:
 
 ```html
 <label for="checkbox1">
@@ -153,9 +153,9 @@ Oprócz checkboksów możemy umieścić w swoim formularzu pola jednokrotnego wy
   </label>
 </div>
 
-W przypadku checkboksów i radiobuttonów również potrzebujemy dodać do `<label>` atrybut `for`. Poeksperymentujcie i usuńcie ten atrybut - co się stanie? Jak wpłynie to na doświadczenie użytkownika podczas używania formularza?
+W przypadku checkboksów i radiobuttonów również potrzebujemy dodać do `<label>` atrybut `for`. Poeksperymentujcie i usuńcie ten atrybut – co się stanie? Jak wpłynie to na doświadczenie użytkownika podczas używania formularza?
 
-Zauważcie również, że w naszych powyższych przykładach używamy atrybutu `name`. Jest on istotny w przypadku radiobuttonów i checkboksów bo wskazuje, że wybieramy elementy spośród konkretnej grupy.
+Zauważcie również, że w naszych powyższych przykładach używamy atrybutu `name`. Jest on istotny w przypadku radiobuttonów i checkboksów, bo wskazuje, że wybieramy elementy spośród konkretnej grupy.
 
 #### Wybieranie plików z dysku
 
@@ -170,11 +170,11 @@ W formularzach istnieje również możliwość dodania pola, dzięki któremu mo
   <input type="file" id="fileUpload">
 </div>
 
-### Pole tekstowe z wieloma liniami (`textarea`)
+### Pole tekstowe z wieloma liniami (`<textarea>`)
 
 Wiemy już, jak wstawiać do naszego formularza pola tekstowe, czyli `<input type="text">`. Co, jeśli jednak użytkownik potrzebuje wpisać większą porcję tekstu, tak jak w przypadku komentarzy pod artykułem na blogu?
 
-Z pomocą przychodzi nam znacznik `<textarea>`, dzięki któremu umożliwimy naszym użytkownikom wpisywanie tekstu w wielu liniach. Będą mieli wtedy więcej miejsca na wyrażenie, na przykład, swoich opinii o naszym tekście.
+Z pomocą przychodzi nam znacznik `<textarea>`, dzięki któremu umożliwimy naszym użytkownikom wpisywanie tekstu w wielu liniach. Będą mieli wtedy więcej miejsca na wyrażenie, na przykład swoich opinii o naszym tekście.
 
 ```html
 <textarea rows="10" cols="30">Napisz coś tutaj</textarea>
@@ -184,7 +184,7 @@ Z pomocą przychodzi nam znacznik `<textarea>`, dzięki któremu umożliwimy nas
   <textarea rows="10" cols="30">Napisz coś tutaj</textarea>
 </div>
 
-### Listy rozwijalne (pola typu *dropdown*)
+### Listy rozwijalne (pola typu <i>dropdown</i>)
 
 Do wstawiania elementu rozwijalnej listy do formularza służy nam znacznik `<select>`.
 
@@ -210,7 +210,7 @@ Do wstawiania elementu rozwijalnej listy do formularza służy nam znacznik `<se
 
 ### Przyciski
 
-Wymieniliśmy już większość bardzo przydatnych kontrolek, jakie można umieścić w formularzu. I na razie moglibyśmy na tym zakończyć, gdyby nie jedna, bardzo popularna - bez której właściwie większość formularzy byłaby mało użyteczna - przyciski. Deklarujemy je w poniższy sposób:
+Wymieniliśmy już większość bardzo przydatnych kontrolek, jakie można umieścić w formularzu. I na razie moglibyśmy na tym zakończyć, gdyby nie jedna, bardzo popularna – bez której właściwie większość formularzy byłaby mało użyteczna – przyciski. Deklarujemy je w poniższy sposób:
 
 ```html
 <button>Kliknij mnie!</button>

--- a/pl/photoshop/README.md
+++ b/pl/photoshop/README.md
@@ -1,8 +1,8 @@
 # Photoshop dla front-endowca
 
-Wydawać by się mogło, że podział pracy pomiędzy koderem a projektantem graficznym jest już od dawna ustalony - grafik tworzy w Photoshopie, a front-endowiec pisze kod. Jednak zawód front-endowca ma to do siebie, że kod jest ściśle powiązany z warstwą wizualną. Dlatego też dbałość o szczegóły i jak najbliższe odwzorowanie projektu graficznego są istotnymi cechami każdego kodera stron WWW.
+Wydawać by się mogło, że podział pracy pomiędzy koderem a projektantem graficznym jest już od dawna ustalony. Grafik tworzy w Photoshopie, a front-endowiec pisze kod. Jednak zawód front-endowca ma to do siebie, że kod jest ściśle powiązany z warstwą wizualną. Dlatego też dbałość o szczegóły i jak najwierniejsze odwzorowanie projektu graficznego są istotnymi cechami każdego kodera stron WWW.
 
-Bywa tak, że grafik szczegółowo opisuje programiście swój projekt wraz z rozmiarami poszczególnych elementów, wielkością tekstu, kolorami itp. Zdarzają się również sytuacje, kiedy grafik kończy pracę na stworzeniu pliku `.psd`, który następnie trafia do front-endowca. Zatem część dalszych działań związanych z wygenerowaniem zasobów tzw. <i>assetów</i> czy pomiarem elementów leży po stronie programisty. Właśnie dlatego zachęcamy Was do zapoznania się z podstawowymi możliwościami Photoshopa. 
+Bywa tak, że grafik szczegółowo opisuje programiście swój projekt wraz z rozmiarami poszczególnych elementów, wielkością tekstu, kolorami itp. Zdarzają się również sytuacje, kiedy grafik kończy pracę na stworzeniu pliku `.psd`, który następnie trafia do front-endowca. Zatem część dalszych działań związanych z wygenerowaniem zasobów tzw. <i>assetów</i> czy pomiarem elementów leży po stronie programisty. Właśnie dlatego zachęcamy Was do zapoznania się z podstawowymi możliwościami Photoshopa.
 
 Zapraszamy na krótki kurs, dzięki któremu dowiemy się:
 <ul>
@@ -10,29 +10,30 @@ Zapraszamy na krótki kurs, dzięki któremu dowiemy się:
 	<li>jak sprawdzać kroje pisma,</li>
 	<li>jak mierzyć wielkości elementów,</li>
 	<li>jak generować assety.</li>
+</ul>
 
-Jeśli jesteś projektantem graficznym lub stawiałeś już pierwsze kroki w Photoshopie możesz pominąć ten rozdział.
+Jeśli jesteś projektantem graficznym lub stawiałeś już pierwsze kroki w Photoshopie, możesz pominąć ten rozdział.
 Na samym końcu znajdziesz Ćwiczenie 13.
 
 ## Ustawienie wybranych jednostek
 
-Najbardziej wygodną dla nas jednostką jest piksel (px). 
-Wybieramy ją wchodząc do ustawień: `Photoshop -> Preferences -> Units & Rulers`.
+Najbardziej wygodną dla nas jednostką jest piksel (`px`).
+Wybieramy ją wchodząc do ustawień: `Photoshop → Preferences → Units & Rulers`.
 
 
-![Ustwienie jednostek w Photoshopie][1]
+![Ustawienie jednostek w Photoshopie][1]
 [1]: /images/ps-units.png
 
-Zalecamy ustawić piksele zarówno dla linijek (Rulers), jak i dla rozmiaru tekstu (Type).
+Zalecamy ustawić piksele zarówno dla linijek (<i>Rulers</i>), jak i dla rozmiaru tekstu (<i>Type</i>).
 
-![Ustwienie pikseli zarówno dla obiektów, jak i rozmiaru tekstu][2]
+![Ustawienie pikseli zarówno dla obiektów, jak i rozmiaru tekstu][2]
 [2]: /images/ps-units-panel.jpg
 
 Dzięki temu od tej pory wszystkie wielkości prezentowane będą w pikselach.
 
 ## Sprawdzanie krojów pisma i wielkości fontu
 
-W celu spradzenia m.in. nazwy kroju, wielkości czy interlinii przyda się nam panel `Character`. Uruchamiamy go poprzez: `Window -> Character`.
+W celu spradzenia m.in. nazwy kroju, wielkości czy interlinii przyda się nam panel `Character`. Uruchamiamy go poprzez: `Window → Character`.
 
 ![Uruchomienie okna "Character"][3]
 [3]: /images/ps-character.jpg
@@ -44,8 +45,8 @@ Powinno pokazać nam się nowe okno, zawierające detale dotyczące naszego teks
 
 Klikajc klawisz `T` automatycznie przechodzimy do narzędzia `Horizontal Type Tool`, oznaczonego charakterystycznym `T` w panelu narzędzi po lewej stronie.
 Dzięki temu możemy kliknąć w dany tekst i odczytać w panelu `Character`, jaki krój pisma został użyty, jaka jest wielkość itd.
-W panelu `Character` znajdziecie wszystko, co będzie potrzebne do wprowadzenia w akurszu stylów, czyli `font-family`, `font-size`, `font-style` oraz `line-height`. 
-Wyjaśnijmy jeszcze czym jest `line-height`. Otóz jest to interlinia, którą możemy określać bezwględnie (w pikselach) lub względnie (w procentach), np.
+W panelu `Character` znajdziecie wszystko, co będzie potrzebne do wprowadzenia w akurszu stylów, czyli `font-family`, `font-size`, `font-style` oraz `line-height`.
+Wyjaśnijmy jeszcze, czym jest `line-height`. Jest to interlinia, którą możemy określać bezwględnie (w pikselach) lub względnie (w procentach), np.
 
 ````css
 	line-height: 150%;
@@ -54,21 +55,21 @@ Wyjaśnijmy jeszcze czym jest `line-height`. Otóz jest to interlinia, którą m
 
 
 ## Pomiar elementów
-Dowiedzieliśmy się już jak sprawdzać wielkość fontu. Pora teraz na obiekty - kontenery, ramki, obrazki. 
+Dowiedzieliśmy się już jak sprawdzać wielkość fontu. Pora teraz na obiekty – kontenery, ramki, obrazki.
 Do pomiaru innych elementów możemy skorzystać z linijki, czyli `Ruler Tool`, która znajduje się w panelu z narzędziami.
 
 !["Wybranie linijki z zestawu narzędzi"][5]
 [5]: /images/ps-ruler.gif
 
-Żeby mieć podgląd do wymiarów przyda nam się panel `Info`. Uruchamiamy go poprzez: `Window -> Info`.
+Żeby mieć podgląd wymiarów przyda nam się panel `Info`. Uruchamiamy go poprzez: `Window → Info`.
 
 !["Panel Info"][6]
 [6]: /images/ps-info-panel.jpg
 
-W panelu `Info` odczytać możecie wartość dla W ( <i>width</i> ), czyli szerokości oraz H ( <i>height</i> ) wysokości.
+W panelu `Info` odczytać możecie wartość dla `W` ( <i>width</i> ), czyli szerokości, oraz `H` ( <i>height</i> ), czyli wysokości.
 
-W przypadku kształtów, oznaczonymi w warstwach kwadracikiem <img src="/images/ps-shape.jpg" style="width: 200px; display: inline-block; vertical-align: middle;" />, 
-do pomiaru możemy wykorzystać panel na samej górze aplikacji, który pokazuje m.in jaki kolor wypełnienia, obramowania oraz wysokość (H) i szerokość (W) ma dany element. 
+W przypadku kształtów, oznaczonych w warstwach kwadracikiem <img src="/images/ps-shape.jpg" style="width: 200px; display: inline-block; vertical-align: middle;" />,
+do pomiaru możemy wykorzystać panel na samej górze aplikacji, który pokazuje m.in jaki kolor wypełnienia, obramowania oraz wysokość (H) i szerokość (W) ma dany element.
 
 
 !["Górny panel z informacjami dotyczącymi elementu"][7]
@@ -78,7 +79,7 @@ do pomiaru możemy wykorzystać panel na samej górze aplikacji, który pokazuje
 [8]: /images/ps-shape-layer.jpg
 
 
-Należy jedynie kliknąć na element wykorzystując `Path Selection Tool`
+Należy jedynie kliknąć na element wykorzystując `Path Selection Tool`.
 
 !["Path Selection Tool"][9]
 [9]: /images/ps-path-selection.gif
@@ -88,42 +89,42 @@ Należy jedynie kliknąć na element wykorzystując `Path Selection Tool`
 
 > #### Important::Ważne
 >
-> Ze względu na pojawienie się wysokiej rozdzielczości, czyli <i>Retiny</i> w komputerach Mac grafiki zaczęto przygotowywać w "podwójnej gęstości". Na czym to polega?
+> Ze względu na pojawienie się wysokiej rozdzielczości, czyli <i>Retiny</i>, w komputerach Mac grafiki zaczęto przygotowywać w "podwójnej gęstości". Na czym to polega?
 >
->Jeśli chcemy, żeby obrazek docelowo wyświetlił się w rozdzielczości 100x100 pikseli, to plik który przygotowujemy "pod Retinę" powinien mieć wymiary 200x200 pikseli, czyli dwukrotnie większą wysokość i szerokość. 
+>Jeśli chcemy, żeby obrazek docelowo wyświetlił się w rozdzielczości 100x100 pikseli, to plik który przygotowujemy "pod Retinę" powinien mieć wymiary 200x200 pikseli, zatem dwukrotnie większą wysokość i szerokość.
 Dlatego też od jakiegoś czasu graficy zwykli projektować strony www w dwukrotnie większej rozdzielczości. Dzięki temu bez problemu można przygotować assety w dwóch rozmiarach: @2x (oznaczenie dla Retiny) oraz normalnych rozmiarach 1:1.
 
->W przypadku grafik takich jak ikony czy logotypy warto jest stosować pliki wektorowe. Najlepszym formatem wektorowym przyjaznym środowisku webowemu jest format `SVG`. 
+>W przypadku grafik, takich jak ikony czy logotypy, warto jest stosować pliki wektorowe. Najlepszym formatem wektorowym przyjaznym środowisku webowemu jest format `SVG`.
 >
 >`SVG` (ang. <i>Scalable Vector Graphic</i>) jest skalowalny i odpowiada naszym potrzebom w temacie responsywności, o której być może już słyszeliście. Dzięki temu możemy zwiększać wymiary obrazka bez utraty jakości w odróżnieniu np. od plików `JPG`.
 
-Jeśli chcesz zagłębić się w temat pikseli oraz Retiny przydatna może być lektura <a href="https://www.smashingmagazine.com/2012/08/towards-retina-web/" target="_blank"> artykułu na Smashing Magazine</a>.
+Jeśli chcesz zagłębić się w temat pikseli oraz Retiny przydatna może być lektura <a href="https://www.smashingmagazine.com/2012/08/towards-retina-web/" target="_blank">artykułu na Smashing Magazine</a>.
 
-Biorąc pod uwagę, to co przeczytaliście w paragrafie powyżej, w pliku `planty.psd` wszystkie elementy oraz wielkość tekstów są dwukrotnie większe. Zatem jeśli będziecie sprawdzać rozmiary elementów i fontów, pamiętajcie o podzieleniu ich przez 2 przy przypisywaniu wartości w CSS.
+Biorąc pod uwagę, to co przeczytaliście w akapicie powyżej, w pliku `planty.psd` wszystkie elementy oraz wielkość tekstów są dwukrotnie większe. Zatem jeśli będziecie sprawdzać rozmiary elementów i fontów, pamiętajcie o podzieleniu ich przez 2 przy przypisywaniu wartości w CSS.
 
-Przykładowo: jeśli tekst "because we care for plants" ma wielkość `36px`, docelowo nadamy w pliku CSS wartość: 
+Przykładowo: jeśli tekst "because we care for plants" ma wielkość `36px`, docelowo nadamy w pliku CSS wartość:
 `font-size: 18px;  /* ponieważ 36px/2 = 18px */`.
 
 
 
 ## Wygenerowanie assetów w Photoshop Creative Cloud
 
-Photoshop Creative Cloud umożliwia wygenerowanie assetów w bardzo prosty i szybki sposób. Wszystko opiera się na warstwach (ang. <i>layers</i>). Zanim przejdziemy do szczegółów warto zajrzeć do zawartości pliku `planty.psd` (plik znajduje się w <a href="../resources/planty-assets/planty-assets.zip">zaktualizowanej paczce z zasobami</a> ). Z reguły każdy z elementów - zdjęcia, obiekty, teksty są tworzone w oddzielnej warstwie. Umożliwia to łatwą modyfikację poszczególnych elementów, jak i późniejsze łatwe zapisanie odseparowanych elementów na potrzeby zakodowania layoutu. 
+Photoshop Creative Cloud umożliwia wygenerowanie assetów w bardzo prosty i szybki sposób. Wszystko opiera się na <b>warstwach</b> (ang. <i>layers</i>). Zanim przejdziemy do szczegółów warto zajrzeć do zawartości pliku `planty.psd` (plik znajduje się w <a href="../resources/planty-assets/planty-assets.zip">zaktualizowanej paczce z zasobami</a> ). Z reguły każdy z elementów – zdjęcia, obiekty, teksty – są tworzone w oddzielnej warstwie. Umożliwia to łatwą modyfikację poszczególnych elementów, jak i późniejsze łatwe zapisanie odseparowanych elementów na potrzeby zakodowania layoutu.
 
 ### Warstwy
-Spróbujmy zajrzeć co kryje się w poszczególnych warstawch, uruchamiając panel warstw: `Window -> Layers`
+Spróbujmy zajrzeć co kryje się w poszczególnych warstawch, uruchamiając panel warstw: `Window → Layers`
 
 ![Panel z warstwami][10]
 [10]: /images/ps-layers-panel.jpg
 
-Poszczególne warstwy powiązane są w grupy, czyli foldery. Dzięki temu każdy element strony pogrupowany jest według swojej przynależności do sekcji na stronie. Warto trzymać porządek i usunąć zbędne warstwy - dzięki temu nie pogubimy się. Rozwijając grupy znajdziecie konkretne elementy.
+Poszczególne warstwy powiązane są w grupy, czyli foldery. Dzięki temu każdy element strony pogrupowany jest według swojej przynależności do sekcji na stronie. Warto trzymać porządek i usunąć zbędne warstwy. Dzięki temu nie pogubimy się. Rozwijając grupy znajdziecie konkretne elementy.
 
 ### Automatyczne generowanie assetów
-Pora na wygenerowanie plików z naszego layoutu. Skorzystamy z funkcjonalności, która zawarta jest w najnowszej wersji programu. Włączamy ją poprzez: `File -> Generate -> Image Assets`.
+Pora na wygenerowanie plików z naszego layoutu. Skorzystamy z funkcjonalności, która zawarta jest w najnowszej wersji programu. Włączamy ją poprzez: `File → Generate → Image Assets`.
 
 Zwróć uwagę, czy opcja ta jest zaznaczona. Jeśli tak, to automatyczne generowanie assetów na podstawie nazwy warstw jest włączone. Możemy zatem przejść do kolejnego kroku.
 
-W wersji Photohop Creative Cloud mamy możliwość szybkiego zapisywania assetów z poziomu warstw. Wystarczy zmienić nazwę danej warsty np. z `flower-2` na `flower-2.png`, wtedy w folderze, gdzie znajduje się nasz plik .psd, zostaną automatycznie wygenerowane assety z zadaną przez nas nazwą i rozszerzeniem. Assety są zapisywane w podfolderze `planty-assets`. Sprawdźmy teraz czy pojawił się tam plik z danym assetem. 
+W wersji Photohop Creative Cloud mamy możliwość szybkiego zapisywania assetów z poziomu warstw. Wystarczy zmienić nazwę danej warsty np. z `flower-2` na `flower-2.png`, wtedy w folderze, gdzie znajduje się nasz plik .psd, zostaną automatycznie wygenerowane assety z zadaną przez nas nazwą i rozszerzeniem. Assety są zapisywane w podfolderze `planty-assets`. Sprawdźmy teraz, czy pojawił się tam plik z danym assetem.
 
 
 !["Automatyczne generowanie assetów][11]
@@ -140,20 +141,10 @@ Taką czynność powtarzamy dla elementów, których będziemy potrzebować do z
 >
 > Pora na tchnięcie trochę życia i kolorów w Planty. Skorzystaj zatem z świeżo nabytej wiedzy i dokonaj następujących zmian na stronie:
 >
-> - Wiesz już, co wchodzi w skład modelu pudełkowego. Odszukaj w projekcie wszystkie elementy, które mogą potrzebować dodania ramki lub wypełnienia (*paddingu*).
+> - Wiesz już, co wchodzi w skład modelu pudełkowego. Odszukaj w projekcie wszystkie elementy, które mogą potrzebować dodania ramki lub wypełnienia (<i>paddingu</i>).
 > - Zwróć uwagę na pojawiające się elementy formularzy (przyciski, `input`y, `textarea`). Nadaj im wygląd zgodny z projektem.
 >
 > Podpowiadamy, że do dokonania powyższych zmian wystarczy Ci znajomość poznanych dotąd właściwości, czyli `color`, `background-color`, `border`, `padding`, `width`, `height`. Jeśli czujesz się komfortowo używając Photoshopa, możesz pobrać tam wartości kolorów oraz poszczególnych wymiarów.
 >
->Przypominamy, że paczkę z Planty można 
-<a href="../resources/planty-assets/planty-assets.zip">pobrać tutaj</a>.
-
-
-
-
-
-
-
-
-
-
+>Przypominamy, że paczkę z Planty można
+<a href="../resources/planty-assets/planty-assets.zip">pobrać z zasobów dołączonych do tutorialu</a>.

--- a/pl/webpage/README.md
+++ b/pl/webpage/README.md
@@ -1,20 +1,20 @@
 # Co zawiera strona internetowa?
 
-W poprzednim rozdziale wspomnieliśmy o edycji tekstu w Wordzie i formatowaniu. Jak pewnie zauważyliście, strony internetowe mają trochę wspólnego z tekstem sformatowanym [RTF](https://pl.wikipedia.org/wiki/Rich_Text_Format): można na nich wyróżnić nagłówki, główny tekst i ilustracje. Zwykle nie są też monochromatyczne - tekst może występować w różnych kolorach i krojach. 
+W poprzednim rozdziale wspomnieliśmy o edycji tekstu w Wordzie i formatowaniu. Jak pewnie zauważyliście, strony internetowe mają trochę wspólnego z tekstem zapisanym w [RTF](https://pl.wikipedia.org/wiki/Rich_Text_Format): można na nich wyróżnić nagłówki, główny tekst i ilustracje. Zwykle nie są też monochromatyczne – tekst może występować w różnych kolorach i krojach.
 
-Skoro występuje tyle podobieństw - mógłbyś zapytać - czemu nie piszemy stron w programach typu Word, skąd w ogóle potrzeba używania tych wszystkich edytorów tekstowych, o których była mowa w poprzednim rozdziale? Czemu tworzenie stron internetowych jest na tyle złożone, żeby zatrudniać w tym celu specjalistów albo zapisywać się na klikunastogodzinne kursy?
+Skoro występuje tyle podobieństw – mógłbyś zapytać – czemu nie piszemy stron w programach typu Word? Skąd w ogóle potrzeba używania tych wszystkich edytorów tekstowych, o których była mowa w poprzednim rozdziale? Czemu tworzenie stron internetowych jest na tyle złożone, żeby zatrudniać w tym celu specjalistów albo zapisywać się na klikunastogodzinne kursy?
 
 ## Dokumenty HTML, czyli jaki język rozumie przeglądarka?
 
-Zdążyliśmy już wspomnieć, że dokumenty, które mają być otwierane przez przeglądarkę powinny być zapisywane w specjalnym formacie (`*.html`). Czym on się różni od zwykłego tekstu? Przecież zawartość naszego pliku jak dotąd była tylko zwykłym tekstem! Jak zatem "powiedzieć" przeglądarce, żeby został sformatowany w określony przez nas sposób?
+Zdążyliśmy już wspomnieć, że dokumenty, które mają być otwierane przez przeglądarkę, powinny być zapisywane w specjalnym formacie (`*.html`). Czym on się różni od zwykłego tekstu? Przecież zawartość naszego pliku jak dotąd była tylko zwykłym tekstem! Jak zatem "powiedzieć" przeglądarce, żeby został sformatowany w określony przez nas sposób?
 
 ### Język HTML
 
-HTML jest to specjalny język znaczników, które umożliwiają nam określenie roli naszych elementów na stronie. Możemy za jego pomocą przekazać, że dany elemenent będzie nagłówkiem, paragrafem tekstu bądź obrazkiem. 
+HTML jest to specjalny język znaczników, które umożliwiają nam określenie ról naszych elementów na stronie. Możemy za jego pomocą przekazać, że dany elemenent będzie nagłówkiem, akapitem bądź obrazkiem.
 
-Jak pewnie już wiesz, strony internetowe nie składają się tylko z bloków tekstu, zwykle zawierają też nawigację, nagłówek, stopkę, odnośniki do innych stron, itd. W tych przypadkach HTML także okazuje się bardzo przydatny.
+Jak pewnie już wiesz, strony internetowe nie składają się tylko z bloków tekstu. Zwykle zawierają też nawigację, nagłówek, stopkę, odnośniki do innych stron, itd. W tych przypadkach HTML także okazuje się bardzo przydatny.
 
-Właściwie możemy myśleć o naszych elementach strony jak o *klockach lego* z których będziemy budować. Każdy taki "klocek" musi być zapisany w specjalny sposób. Nasze elementy opisywane są przez **tagi HTML**. Jak wygląda przykładowy tag?
+Właściwie możemy myśleć o naszych elementach strony jak o <i>klockach lego</i>, z których będziemy budować. Każdy taki "klocek" musi być zapisany w specjalny sposób. Nasze elementy opisywane są przez <b>tagi HTML</b>. Jak wygląda przykładowy tag?
 
 ```html
 <element>
@@ -39,13 +39,13 @@ Poszczególne elementy HTML mogą być zwykle zagnieżdżane jeden wewnątrz dru
 </element>
 ```
 
-Warto już tutaj zaznaczyć, że nie wszystkie elementy wymagają tagów zamykających. Nie można też zagnieżdżać wewnątrz nich innych elementów. Są to tak zwane *puste elementy*. Które to konkretnie, dowiecie się już niedługo w rozdziale zapoznającym z tajnikami HTML.
+Warto już tutaj zaznaczyć, że nie wszystkie elementy wymagają tagów zamykających. Nie można też zagnieżdżać wewnątrz nich innych elementów. Są to tak zwane <i>puste elementy</i>. Które to konkretnie, dowiecie się już niedługo w rozdziale zapoznającym z tajnikami HTML.
 
 ```html
 <empty>
 ```
 
-Elementy mogą również zawierać *atrybuty*. Atrybuty elementów zapisywane są w ten sposób:
+Elementy mogą również zawierać <i>atrybuty</i>. Atrybuty elementów zapisywane są w ten sposób:
 
 ```html
 <element attribute="value"></element>
@@ -55,25 +55,25 @@ Elementy mogą również zawierać *atrybuty*. Atrybuty elementów zapisywane s�
 
 ### Separacja zawartości i prezentacji
 
-Zanim zabierzesz się do pisania swojego pierwszego kodu warto wspomnieć o bardzo ważnej regule, która obowiązuje programistów stron internetowych, a jest nią **separacja zawartości i prezentacji**.
+Zanim zabierzesz się do pisania swojego pierwszego kodu, warto wspomnieć o bardzo ważnej regule, która obowiązuje programistów stron internetowych, a jest nią **separacja zawartości i prezentacji**.
 
-Dowiedzieliśmy się już, że język HTML służy do opisu treści stron internetowych. Nie zawiera on żadnych informacji o tym, jak powinna wyglądać nasza strona. Aby nadać jej nasz wymarzony wygląd musimy stworzyć "skórkę". W programowaniu WWW do tego celu służą **kaskadowe arkusze styli**, czyli **CSS** (Cascading Style Sheets).
+Dowiedzieliśmy się już, że język HTML służy do opisu treści stron internetowych. Nie zawiera on żadnych informacji o tym, jak powinna wyglądać nasza strona. Aby nadać jej nasz wymarzony wygląd, musimy stworzyć "skórkę". W programowaniu WWW do tego celu służą <b>kaskadowe arkusze stylów</b>, czyli <b>CSS</b> (ang. <i>Cascading Style Sheets</i>).
 
 > #### Important::Ważne
 >
->Istnieje możliwość deklarowania styli bezpośrednio w kodzie HTML (za pomocą atrybutu `style`):
+>Istnieje możliwość deklarowania stylów bezpośrednio w kodzie HTML (za pomocą atrybutu `style`):
 >```html
 <div style="color:red;"></div>
 ```
->Nie jest to jednak dobrą praktyką, ponieważ kod opisujący prezentację strony jest ściśle powiązany z kodem opisującym jego treść. Dużo łatwiej wprowadzać zmiany w wyglądzie strony oraz utrzymywać kod, kiedy te dwie warstwy są logicznie od siebie oddzielone - to właśnie nazywamy **separacją zawartości i prezentacji**.
+>Nie jest to jednak dobrą praktyką, ponieważ kod opisujący prezentację strony jest ściśle powiązany z kodem opisującym jej treść. Dużo łatwiej wprowadzać zmiany w wyglądzie strony oraz utrzymywać kod, kiedy te dwie warstwy są logicznie od siebie oddzielone. To właśnie nazywamy **separacją zawartości i prezentacji**.
 >
 >Style piszemy w osobnych plikach z rozszerzeniem `*.css` i dołączamy do naszego dokumentu HTML w specjalny sposób. Jak? Dowiesz się już niedługo!
 
 ### Język CSS
 
-Język CSS różni się znacznie w zapisie od HTML. HTML pozwala nam stworzyć treść strony, natomiast CSS to lista reguł opisujących w jaki sposób jej elementy mają zostać wyświetlone przez przeglądarkę. 
+Język CSS różni się znacznie w zapisie od HTML. HTML pozwala nam stworzyć treść (strukturę) strony, natomiast CSS to lista reguł opisujących w jaki sposób jej elementy mają zostać wyświetlone przez przeglądarkę.
 
-Składnia CSS operuje na **selektorach**. Za pomocą selektorów wybieramy elementy strony, którym chcemy nadać określony wygląd. Kod zapisuje się w sposób:
+Składnia CSS operuje na <b>selektorach</b>. Za pomocą selektorów wybieramy elementy strony, którym chcemy nadać określony wygląd. Kod zapisuje się w sposób:
 
 ```css
 selektor {
@@ -89,4 +89,4 @@ p {
 }
 ```
 
-Ustawia kolor fontu na niebieski dla wszystkich elementów typu `p` (`p` to znacznik reprezentujący akapit, z angielskiego *paragraph*).
+Powyższy kod ustawia kolor fontu na niebieski dla wszystkich elementów typu `p` (`p` to znacznik reprezentujący akapit, z angielskiego <i>paragraph</i>).


### PR DESCRIPTION
Hej,

przygotowałem mały PR z bardzo _subiektywnymi_ zmianami. Mam jednak nadzieję, że zostaną dołączone. Co zrobiłem?
## Ogólne
- Dla skrótów klawiszowych dodałem odpowiednie oznaczenie przy pomocy `kbd`.
- Wszystkie terminy techniczne i nazwy poszczególnych rzeczy zmieniłem z generowanego przez Markdown `em` na `i`, względnie `b`. `em` bowiem – zgodnie ze specyfikacją HTML5 – służy do oznaczania rozłożenia akcentu, nie terminów technicznych. Tak samo zamieniłem niektóre `strong` na `b`.
- No i zamieniłem "-" w tekstach na "–".
- Zamieniłem "paragrafy tekstu" na "akapity". Mimo wszystko w języku polskim paragraf ma [całkiem inne znaczenie](http://sjp.pwn.pl/sjp/paragraf;2570629.html) niż w języku angielskim.
- Przeredagowałem trochę teksty, żeby (oczywiście IMO) lepiej brzmiały (np. zmieniłem ciut szyk zdań czy usunąłem powtórzenia). Myślę, że nie zaszkodziłem tymi zmianami ;)
- Zamieniłem wszystkie "styli" na "stylów". Forma "styli" **[nie istnieje](http://sjp.pwn.pl/so/styl;4515998.html)**.
- W miarę możliwości ujednoliciłem zapis tagów.
- Poprawiłem też parę linków "tutaj". Jest to ważne zwłaszcza dla czytników ekranowych, tworzących listy linków z danego dokumentu.
- Poprawiłem kilka "ilości" na "liczbę". "Ilość" używa się bowiem do rzeczy niepoliczalnych, a "liczba" do policzalnych.
- Poprawiłem zapis przedrostka "pseudo" z innymi wyrazami. Przedrostek ten piszemy z innymi wyrazami (niebędącymi nazwami własnymi) [łącznie](http://sjp.pwn.pl/zasady/148-33-Pisownia-wyrazow-z-przedrostkami;629484.html), zatem "pseudoklasa", "pseudoelement" itd.
- W opisach menu podmieniłem `->` na `→` (ładniej wygląda!).
- Sformułowanie "dla ustalenia uwagi" jest… po prostu niepolskie. Zmieniłem na odpowiedniki.
- Ach, no i kilka literówek też machnąłem ;)
## `html-code`
- Ujednoliciłem zapis `DOCTYPE`.
- Dodałem notkę o atrybucie `[lang]`.
## `html-elements`
- Dodałem notkę o `[target]`.
- Dodałem przy `[alt]` informację o czytnikach ekranowych.
## `css-code`
- Dodałem notkę o stylowaniu po `[id]` – czemu jest uważane za złą praktykę.
## `css-cascade`
- Usunąłem fragment o dziedziczeniu tła, bo tuż pod nim znajduje się lista niedziedzicznych cech, wśród których jest tło.
## `css-layout`
- `css-floats` → dodałem linka do kilku innych sposobów clearowania.
## `css-animations`
- `css-keyframes` → dodałem opis do `animation-timing-function`.
## Do rozważenia
- Może warto ujednolić zapis terminów technicznych? Obecnie jest to mieszanka pogrubienia i kursywy.
- Może ujednolicić formę zwracania się do czytelnika? Aktualnie jest mieszane "Ty" z "My".
- Może do zapisywania znaczników i ich atrybutów użyć składni CSS?
- Trochę śmieszą przykłady kodu CSS, które opisują "selektory oparte na relacji elementów w drzewku dokumentu HTML", po czym sam przykład jest robiony przy pomocy `[style]` z `!important`. Może dobrym pomysłem byłoby wyrzucenie wszystkich przykładów do CodePena? Dzięki temu stałyby się także bardziej interaktywne i zachęcały do samodzielnego "hakowania".
- [Border box](http://www.paulirish.com/2012/box-sizing-border-box-ftw/) jest <i>de facto</i> standardem jeśli chodzi o box model. Wydaje mi się, że powinien zostać opisany w `css-box-model` – i to nie jako dodatek, ale **podstawowy** box model.
- `css-positioning` → zastanawiam się, czy poszczególne sposoby pozycjonowania nie wyjaśnić jakoś inaczej. Określenie pozycjonowania relatywnego jako pozycjonowania elementu względem jego samego jest IMO dość mylące.
- `css-rwd-basics` → może zamiast o mobile first lepiej napisać o content first?
- Może warto dopisać o flexboxie coś? Zwłaszcza w `css-grid` i zwłaszcza dlatego, że BS4 będzie mieć siatkę na nim.

---

Niemniej tutek jest bardzo dobry. Chyba jeden z najlepszych, jakie widziałem po polsku. Gratuluję :)
